### PR TITLE
Encryption at rest, chunk-level provenance, incremental connector sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,45 @@ and when `FILENERGY_SYNC_SCHEDULER=false`.
   `/file/from_url/` with `Authorization: Bearer …`. The endpoint accepts
   either session cookies or API keys.
 
+### Encryption at rest
+
+- `services/crypto.py` exposes a Fernet-backed `EncryptedText` SQLAlchemy
+  type. Sensitive columns — `File.text_content`, `Chunk.embedding`,
+  `ConnectorAccount.access_token`/`refresh_token`, `User.totp_secret` —
+  go through it.
+- Activate by setting `FILENERGY_ENCRYPTION_KEY` (mint one with
+  `python manage.py generate-encryption-key`). Without the key, columns
+  round-trip as plaintext — backwards compatible with old data and dev
+  environments.
+- New writes get an `enc:` prefix; old plaintext rows coexist with new
+  encrypted ones. Run `python manage.py reencrypt` once after enabling
+  to back-fill.
+
+### Chunk-level provenance
+
+Every assistant turn now creates `MessageCitation` rows linking
+the `Message` to each retrieved `Chunk` + the cosine score. The dashboard
+surfaces a "Most-cited chunks" panel with the snippet inline, and the
+"Most-cited files" panel now uses real citation counts instead of the
+prior coarse `ask.answered` event proxy.
+
+### Incremental connector sync
+
+`ConnectorAccount.sync_cursor` is the resume token; each connector uses
+its native cursor primitive:
+
+- **Drive** — `q=modifiedTime > '<RFC3339>'`, cursor = newest
+  `modifiedTime` from the latest page.
+- **Notion** — `start_cursor` / `next_cursor`. Cleared when the result
+  set is exhausted so the next tick starts over.
+- **Dropbox** — first call hits `/2/files/list_folder`, subsequent calls
+  hit `/list_folder/continue` with the saved cursor (delta-native).
+- **Slack** — `oldest=<ts>`. New deltas are appended to the existing
+  per-channel transcript file rather than written as fresh files.
+
 ### Tests
 
-**614 tests, 97.7% coverage** (pytest + pytest-cov).
+**650 tests, 97.5% coverage** (pytest + pytest-cov).
 
 ## Where we sit vs the competition
 
@@ -446,11 +482,11 @@ TLS terminated.
 
 ## Roadmap
 
-- **Per-connector OAuth scope tightening** (Slack/Notion currently ask
-  broader scopes than strictly needed for read-only sync).
-- **Connector incremental sync** with cursors / `modifiedTime > since`
-  (today's loop pulls a recent slice and dedupes by name).
-- **More chunk-level provenance** on dashboard (which chunk got cited,
-  not just which file).
-- **Encryption at rest** for `embedding`, `text_content`, `access_token`
-  columns (envelope encryption with a KEK in env / KMS).
+- **Per-connector OAuth scope tightening** (Slack still asks `groups:*`
+  scopes; Notion + Dropbox could be narrower).
+- **KEK rotation** via `MultiFernet` so secrets can rotate without a
+  full re-encrypt pass.
+- **Citation drill-through** — click a chunk on the dashboard and jump
+  to the source paragraph in the file detail view.
+- **Cron / RQ-driven scheduler** (today's daemon thread is fine for one
+  Filenergy process; scale-out needs a real worker).

--- a/filenergy/models/__init__.py
+++ b/filenergy/models/__init__.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from filenergy import db
+from filenergy.services.crypto import EncryptedText
 
 
 def utcnow():
@@ -41,7 +42,7 @@ class User(BaseModel):
     google_id = db.Column(db.String(64), unique=True, nullable=True, index=True)
 
     # 2FA
-    totp_secret = db.Column(db.String(64), nullable=True)
+    totp_secret = db.Column(EncryptedText, nullable=True)
     totp_enabled_at = db.Column(db.DateTime, nullable=True)
     recovery_codes_json = db.Column(db.Text, nullable=True)  # list of hashed codes
 
@@ -181,7 +182,7 @@ class File(BaseModel):
 
     indexed_at = db.Column(db.DateTime, nullable=True)
     index_error = db.Column(db.Text, nullable=True)
-    text_content = db.Column(db.Text, nullable=True)
+    text_content = db.Column(EncryptedText, nullable=True)
     summary = db.Column(db.Text, nullable=True)
     suggested_questions_json = db.Column(db.Text, nullable=True)
 
@@ -260,7 +261,12 @@ class Chunk(BaseModel):
     file_id = db.Column(db.Integer, db.ForeignKey("file.id"), index=True)
     position = db.Column(db.Integer)
     content = db.Column(db.Text)
-    embedding = db.Column(db.Text)
+    embedding = db.Column(EncryptedText)
+
+    citations = db.relationship(
+        "MessageCitation", backref="chunk", lazy="dynamic",
+        cascade="all, delete-orphan",
+    )
 
 
 class Conversation(BaseModel):
@@ -295,6 +301,31 @@ class Message(BaseModel):
     role = db.Column(db.String(16))
     content = db.Column(db.Text)
     sources_json = db.Column(db.Text, nullable=True)
+
+    citations = db.relationship(
+        "MessageCitation", backref="message", lazy="dynamic",
+        cascade="all, delete-orphan",
+    )
+
+
+class MessageCitation(BaseModel):
+    """One assistant turn → one cited chunk + the retrieval score.
+
+    `Message.sources_json` stays the canonical render shape; this table
+    is the queryable index that lets the dashboard answer "which chunks
+    actually got used?" without re-parsing JSON in app code.
+    """
+
+    __tablename__ = "message_citation"
+
+    id = db.Column(db.Integer, primary_key=True)
+    message_id = db.Column(
+        db.Integer, db.ForeignKey("message.id"), index=True
+    )
+    chunk_id = db.Column(
+        db.Integer, db.ForeignKey("chunk.id"), index=True
+    )
+    score = db.Column(db.Float)
 
 
 class Event(BaseModel):
@@ -417,8 +448,9 @@ class ConnectorAccount(BaseModel):
     workspace_id = db.Column(db.Integer, db.ForeignKey("workspace.id"), index=True)
     kind = db.Column(db.String(32), index=True)  # "google_drive", etc.
     account_label = db.Column(db.String(255))  # email / handle
-    access_token = db.Column(db.Text)
-    refresh_token = db.Column(db.Text, nullable=True)
+    access_token = db.Column(EncryptedText)
+    refresh_token = db.Column(EncryptedText, nullable=True)
+    sync_cursor = db.Column(db.Text, nullable=True)
     expires_at = db.Column(db.DateTime, nullable=True)
     last_synced_at = db.Column(db.DateTime, nullable=True)
     last_error = db.Column(db.Text, nullable=True)

--- a/filenergy/services/chat.py
+++ b/filenergy/services/chat.py
@@ -45,6 +45,10 @@ class Source:
 class Answer:
     text: str
     sources: list[Source]
+    # Per-chunk provenance: (chunk_id, score) for every retrieved chunk that
+    # made it into the prompt. Used by conversations.add_assistant_message
+    # to populate the MessageCitation index.
+    chunk_citations: list = None  # type: ignore[assignment]
 
 
 @lru_cache(maxsize=1)
@@ -64,9 +68,11 @@ def is_configured() -> bool:
     return bool(settings.ANTHROPIC_API_KEY) and embeddings.is_configured()
 
 
-def _build_context(retrieved) -> tuple[str, list[Source]]:
+def _build_context(retrieved):
+    """Returns (context_str, sources_sorted, chunk_citations)."""
     blocks = []
     sources: dict[int, Source] = {}
+    chunk_citations: list[tuple[int, float]] = []
     for chunk, score in retrieved:
         f: File = chunk.file
         blocks.append(
@@ -74,12 +80,17 @@ def _build_context(retrieved) -> tuple[str, list[Source]]:
             f"{chunk.content}\n"
             f"</excerpt>"
         )
+        chunk_citations.append((chunk.id, float(score)))
         if f.id not in sources or sources[f.id].score < score:
             sources[f.id] = Source(
                 file_id=f.id, name=f.name, url=f.url, score=score
             )
     context = "<context>\n" + "\n\n".join(blocks) + "\n</context>"
-    return context, sorted(sources.values(), key=lambda s: -s.score)
+    return (
+        context,
+        sorted(sources.values(), key=lambda s: -s.score),
+        chunk_citations,
+    )
 
 
 def _build_messages(conversation_messages, context: str, question: str) -> list[dict]:
@@ -122,9 +133,9 @@ def answer_question(
         workspace, question, collection_id=collection_id, file_id=file_id
     )
     if not retrieved:
-        return Answer(text=_no_results_message(), sources=[])
+        return Answer(text=_no_results_message(), sources=[], chunk_citations=[])
 
-    context, sources = _build_context(retrieved)
+    context, sources, chunk_citations = _build_context(retrieved)
     messages = _build_messages(list(history), context, question)
 
     with _client().messages.stream(
@@ -146,7 +157,11 @@ def answer_question(
         (b.text for b in message.content if getattr(b, "type", None) == "text"),
         "",
     ).strip()
-    return Answer(text=text or "(no answer)", sources=sources)
+    return Answer(
+        text=text or "(no answer)",
+        sources=sources,
+        chunk_citations=chunk_citations,
+    )
 
 
 def _sse(event: str, data) -> str:
@@ -175,10 +190,10 @@ def stream_answer(
     if not retrieved:
         text = _no_results_message()
         yield _sse("token", {"text": text})
-        yield _sse("done", {"text": text, "sources": []})
+        yield _sse("done", {"text": text, "sources": [], "chunk_citations": []})
         return
 
-    context, sources = _build_context(retrieved)
+    context, sources, chunk_citations = _build_context(retrieved)
     messages = _build_messages(list(history), context, question)
 
     parts: list[str] = []
@@ -206,5 +221,9 @@ def stream_answer(
     text = ("".join(parts)).strip() or "(no answer)"
     yield _sse(
         "done",
-        {"text": text, "sources": [asdict(s) for s in sources]},
+        {
+            "text": text,
+            "sources": [asdict(s) for s in sources],
+            "chunk_citations": chunk_citations,
+        },
     )

--- a/filenergy/services/connectors.py
+++ b/filenergy/services/connectors.py
@@ -180,18 +180,24 @@ class GoogleDriveConnector(BaseConnector):
 
     def sync(self, account: ConnectorAccount, *, user, workspace,
              max_files: int = 25) -> dict:
+        """Incremental: only ingest files modified after the saved cursor.
+
+        Drive's `q` parameter takes RFC-3339 `modifiedTime` so we resume
+        from `account.sync_cursor` instead of re-listing the whole drive
+        each tick.
+        """
         access = self._ensure_fresh(account)
         headers = {"Authorization": f"Bearer {access}"}
 
-        listing = _get_json(
-            _DRIVE_LIST_URL,
-            params={
-                "pageSize": str(max_files),
-                "fields": "files(id,name,mimeType,modifiedTime,size)",
-                "orderBy": "modifiedTime desc",
-            },
-            headers=headers,
-        )
+        params = {
+            "pageSize": str(max_files),
+            "fields": "files(id,name,mimeType,modifiedTime,size)",
+            "orderBy": "modifiedTime desc",
+        }
+        if account.sync_cursor:
+            params["q"] = f"modifiedTime > '{account.sync_cursor}'"
+
+        listing = _get_json(_DRIVE_LIST_URL, params=params, headers=headers)
         items = listing.get("files", [])
 
         from filenergy.models import File
@@ -217,6 +223,9 @@ class GoogleDriveConnector(BaseConnector):
             )
             created += 1
 
+        # Cursor = newest modifiedTime we saw (already DESC-sorted).
+        if items and items[0].get("modifiedTime"):
+            account.sync_cursor = items[0]["modifiedTime"]
         account.last_synced_at = utcnow()
         account.last_error = None
         db.session.commit()
@@ -338,11 +347,16 @@ class NotionConnector(BaseConnector):
             "Notion-Version": _NOTION_API_VERSION,
             "Content-Type": "application/json",
         }
-        result = _post_json(_NOTION_SEARCH_URL, {
+        body: dict = {
             "filter": {"property": "object", "value": "page"},
             "page_size": max_pages,
-        }, headers=headers)
+        }
+        # Resume from where we left off via Notion's next_cursor.
+        if account.sync_cursor:
+            body["start_cursor"] = account.sync_cursor
+        result = _post_json(_NOTION_SEARCH_URL, body, headers=headers)
         pages = result.get("results", [])
+        next_cursor = result.get("next_cursor")
 
         from filenergy.models import File
         created = 0
@@ -367,6 +381,9 @@ class NotionConnector(BaseConnector):
             )
             created += 1
 
+        # Save the next page cursor; clear it when the result set is exhausted
+        # so the following sync starts from the beginning again.
+        account.sync_cursor = next_cursor or None
         account.last_synced_at = utcnow()
         account.last_error = None
         db.session.commit()
@@ -505,17 +522,21 @@ class DropboxConnector(BaseConnector):
 
     def sync(self, account: ConnectorAccount, *, user, workspace,
              max_files: int = 50) -> dict:
+        """Dropbox is delta-native via list_folder/continue + cursors."""
         access = self._ensure_fresh(account)
         headers = {
             "Authorization": f"Bearer {access}",
             "Content-Type": "application/json",
         }
-        listing = _post_json(_DROPBOX_LIST_URL, {
-            "path": "",
-            "recursive": False,
-            "limit": max_files,
-        }, headers=headers)
+        if account.sync_cursor:
+            url = _DROPBOX_LIST_URL + "/continue"
+            body = {"cursor": account.sync_cursor}
+        else:
+            url = _DROPBOX_LIST_URL
+            body = {"path": "", "recursive": False, "limit": max_files}
+        listing = _post_json(url, body, headers=headers)
         entries = listing.get("entries", [])
+        next_cursor = listing.get("cursor")
 
         from filenergy.models import File
         created = 0
@@ -546,6 +567,7 @@ class DropboxConnector(BaseConnector):
             )
             created += 1
 
+        account.sync_cursor = next_cursor or account.sync_cursor
         account.last_synced_at = utcnow()
         account.last_error = None
         db.session.commit()
@@ -640,7 +662,14 @@ class SlackConnector(BaseConnector):
 
     def sync(self, account: ConnectorAccount, *, user, workspace,
              max_channels: int = 5, max_messages: int = 200) -> dict:
+        """Incremental: pull only messages newer than `oldest` cursor.
+
+        We append the new transcript to the existing per-channel file
+        instead of writing a fresh one each tick, so the conversation
+        grows over time.
+        """
         headers = {"Authorization": f"Bearer {account.access_token}"}
+        oldest = account.sync_cursor or "0"
 
         listing = _get_json(
             _SLACK_LIST_CHANNELS_URL,
@@ -654,20 +683,29 @@ class SlackConnector(BaseConnector):
         from filenergy.models import File
         created = 0
         skipped = 0
+        max_ts_seen = oldest
         for channel in channels:
             name = channel.get("name") or "channel"
             file_name = f"slack-{name}.txt"
+            transcript, latest_ts = _slack_channel_transcript(
+                channel["id"], headers, max_messages, oldest=oldest,
+            )
+            if not transcript:
+                skipped += 1
+                continue
+            if latest_ts and (not max_ts_seen or latest_ts > max_ts_seen):
+                max_ts_seen = latest_ts
             existing = File.query.filter_by(
                 workspace_id=workspace.id, name=file_name,
             ).first()
             if existing is not None:
-                skipped += 1
-                continue
-            transcript = _slack_channel_transcript(
-                channel["id"], headers, max_messages
-            )
-            if not transcript:
-                skipped += 1
+                # Append delta to the existing transcript.
+                try:
+                    with open(existing.path, "ab") as fd:
+                        fd.write(b"\n" + transcript.encode("utf-8"))
+                    skipped += 1  # not a "new file"
+                except OSError:
+                    skipped += 1
                 continue
             ingestion.materialize_blob(
                 user=user, workspace=workspace, name=file_name,
@@ -675,32 +713,40 @@ class SlackConnector(BaseConnector):
             )
             created += 1
 
+        if max_ts_seen and max_ts_seen != oldest:
+            account.sync_cursor = max_ts_seen
         account.last_synced_at = utcnow()
         account.last_error = None
         db.session.commit()
         return {"created": created, "skipped": skipped}
 
 
-def _slack_channel_transcript(channel_id: str, headers: dict, limit: int) -> str:
+def _slack_channel_transcript(channel_id: str, headers: dict, limit: int,
+                              *, oldest: str = "0") -> tuple[str, str]:
+    """Return (transcript, latest_timestamp). Empty string + "" on failure."""
     try:
         body = _get_json(
             _SLACK_HISTORY_URL,
-            params={"channel": channel_id, "limit": str(limit)},
+            params={"channel": channel_id, "limit": str(limit), "oldest": oldest},
             headers=headers,
         )
     except ConnectorError as exc:
         log.warning("Slack history failed for %s: %s", channel_id, exc)
-        return ""
+        return "", ""
     if not body.get("ok"):
-        return ""
+        return "", ""
     lines = []
+    latest_ts = ""
     for msg in reversed(body.get("messages", [])):  # oldest first
         text = msg.get("text") or ""
+        ts = msg.get("ts") or ""
+        if ts and ts > latest_ts:
+            latest_ts = ts
         if not text:
             continue
         user_id = msg.get("user") or msg.get("bot_id") or "?"
         lines.append(f"{user_id}: {text}")
-    return "\n".join(lines)
+    return "\n".join(lines), latest_ts
 
 
 # ---------------------------------------------------------------------------

--- a/filenergy/services/conversations.py
+++ b/filenergy/services/conversations.py
@@ -54,7 +54,8 @@ def add_user_message(conversation: Conversation, text: str) -> Message:
 
 
 def add_assistant_message(
-    conversation: Conversation, text: str, sources
+    conversation: Conversation, text: str, sources,
+    *, chunk_citations: list | None = None,
 ) -> Message:
     if hasattr(sources[0] if sources else None, "__dataclass_fields__"):
         sources_payload = [asdict(s) for s in sources]
@@ -69,6 +70,29 @@ def add_assistant_message(
     )
     db.session.add(msg)
     db.session.commit()
+
+    # Per-chunk provenance (queryable index for the dashboard).
+    if chunk_citations:
+        from filenergy.models import MessageCitation
+
+        for entry in chunk_citations:
+            try:
+                chunk_id, score = entry
+            except (TypeError, ValueError):
+                continue
+            if chunk_id is None:
+                continue
+            try:
+                cid = int(chunk_id)
+                s = float(score)
+            except (TypeError, ValueError):
+                continue
+            db.session.add(MessageCitation(
+                message_id=msg.id,
+                chunk_id=cid,
+                score=s,
+            ))
+        db.session.commit()
     return msg
 
 

--- a/filenergy/services/crypto.py
+++ b/filenergy/services/crypto.py
@@ -1,0 +1,141 @@
+"""Envelope encryption for sensitive columns.
+
+`FILENERGY_ENCRYPTION_KEY` (a Fernet key, 32 url-safe base64 bytes)
+controls whether at-rest encryption is on. Without it, columns wrapped
+with `EncryptedText` round-trip as plaintext — handy in dev and for
+backwards compatibility with rows written before this feature shipped.
+
+When the key is set, new writes get prefixed with `enc:`; reads detect
+the prefix and decrypt. Mixed rows (some encrypted, some not) coexist
+peacefully so an upgrade can re-encrypt lazily without downtime.
+
+Run `python manage.py reencrypt` after enabling the key to back-fill
+existing rows.
+"""
+from __future__ import annotations
+
+import base64
+import logging
+import os
+
+from sqlalchemy import Text
+from sqlalchemy.types import TypeDecorator
+
+log = logging.getLogger(__name__)
+
+
+_PREFIX = "enc:"
+
+
+def is_configured() -> bool:
+    return bool(os.environ.get("FILENERGY_ENCRYPTION_KEY"))
+
+
+def _fernet():
+    """Lazy-import + lazy-construct so the Flask app boots without `cryptography`
+    in the import path until somebody actually encrypts something."""
+    key = os.environ.get("FILENERGY_ENCRYPTION_KEY")
+    if not key:
+        return None
+    try:
+        from cryptography.fernet import Fernet
+    except ImportError as exc:  # pragma: no cover — cryptography pulled in by pypdf
+        raise RuntimeError("cryptography is required for at-rest encryption") from exc
+    return Fernet(key.encode("utf-8") if isinstance(key, str) else key)
+
+
+def generate_key() -> str:
+    """Convenience for `python manage.py generate-encryption-key`."""
+    from cryptography.fernet import Fernet
+    return Fernet.generate_key().decode("ascii")
+
+
+def encrypt(plaintext: str | None) -> str | None:
+    if plaintext is None:
+        return None
+    if not is_configured():
+        return plaintext
+    fernet = _fernet()
+    if fernet is None:
+        return plaintext
+    if isinstance(plaintext, str) and plaintext.startswith(_PREFIX):
+        # Already encrypted — don't double-wrap (idempotent).
+        return plaintext
+    token = fernet.encrypt(plaintext.encode("utf-8")).decode("ascii")
+    return _PREFIX + token
+
+
+def decrypt(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.startswith(_PREFIX):
+        # Either empty / numeric / already-plaintext — pass through.
+        return value
+    fernet = _fernet()
+    if fernet is None:
+        # The row is encrypted but we lost the key. Surface the prefixed
+        # string so the failure mode is visible rather than silent garbage.
+        log.error("Decryption requested but FILENERGY_ENCRYPTION_KEY is unset")
+        return value
+    try:
+        return fernet.decrypt(value[len(_PREFIX):].encode("ascii")).decode("utf-8")
+    except Exception:
+        log.exception("Failed to decrypt column value")
+        return value
+
+
+class EncryptedText(TypeDecorator):
+    """Text column that auto-encrypts on write and decrypts on read."""
+
+    impl = Text
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        return encrypt(value)
+
+    def process_result_value(self, value, dialect):
+        return decrypt(value)
+
+
+def reencrypt_all(*, batch: int = 500) -> dict:
+    """Walk every encrypted column and re-write each row through the type.
+
+    A no-op when the key isn't set. Useful after rotating the key (rotate
+    by setting both old and new keys via MultiFernet — out of scope here)
+    or after enabling encryption on existing data.
+    """
+    from sqlalchemy.orm.attributes import flag_modified
+
+    from filenergy import db
+    from filenergy.models import Chunk, ConnectorAccount, File, User
+
+    counts = {"file": 0, "chunk": 0, "connector_account": 0, "user": 0}
+    if not is_configured():
+        return counts
+
+    def _touch(obj, attr):
+        """Force the column to round-trip through the type decorator."""
+        value = getattr(obj, attr)
+        if value is None:
+            return False
+        # Re-assign + mark dirty so SQLAlchemy emits an UPDATE even when
+        # the post-decoded plaintext is unchanged.
+        setattr(obj, attr, value)
+        flag_modified(obj, attr)
+        return True
+
+    for f in File.query.all():
+        if _touch(f, "text_content"):
+            counts["file"] += 1
+    for c in Chunk.query.yield_per(batch):
+        if _touch(c, "embedding"):
+            counts["chunk"] += 1
+    for a in ConnectorAccount.query.all():
+        if _touch(a, "access_token"):
+            counts["connector_account"] += 1
+        _touch(a, "refresh_token")
+    for u in User.query.all():
+        if _touch(u, "totp_secret"):
+            counts["user"] += 1
+    db.session.commit()
+    return counts

--- a/filenergy/templates/dashboard/index.html
+++ b/filenergy/templates/dashboard/index.html
@@ -60,8 +60,28 @@
   {% if top_files %}
   <div class="chart-title">Most-cited files</div>
   <ul class="top-files">
-    {% for name, hits in top_files %}
-      <li>{{ name }} <span style="color:#888;">· {{ hits }} citations</span></li>
+    {% for fid, name, url, hits in top_files %}
+      <li>
+        <a href="{{ url_for('file.detail', file_id=fid) }}">{{ name }}</a>
+        <span style="color:#888;">· {{ hits }} citations</span>
+      </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+
+  {% if top_chunks %}
+  <div class="chart-title" style="margin-top:18px;">Most-cited chunks</div>
+  <ul class="top-files">
+    {% for cid, pos, content, fname, furl, hits in top_chunks %}
+      <li>
+        <strong>{{ fname }}</strong>
+        <span style="color:#888;">· chunk #{{ pos }} · {{ hits }} citations</span>
+        <div style="color:#555; font-size:13px; margin-top:2px;
+                    overflow:hidden; text-overflow:ellipsis;
+                    white-space:nowrap; max-width:100%;">
+          {{ (content or '')[:200] }}{% if content and content|length > 200 %}…{% endif %}
+        </div>
+      </li>
     {% endfor %}
   </ul>
   {% endif %}

--- a/filenergy/views/ask.py
+++ b/filenergy/views/ask.py
@@ -195,7 +195,8 @@ def ask():
         return jsonify(error="Failed to answer: " + str(exc)), 500
 
     msg = conversations.add_assistant_message(
-        conversation, answer.text, answer.sources
+        conversation, answer.text, answer.sources,
+        chunk_citations=answer.chunk_citations,
     )
     events.log_event(
         events.ASK_ANSWERED,
@@ -290,6 +291,7 @@ def ask_stream():
 
         full_text_parts: list[str] = []
         sources_payload: list[dict] = []
+        chunk_citations: list = []
         for chunk_str in chat.stream_answer(
             workspace_obj, question, history=history_objs_local,
             collection_id=scope_collection_id, file_id=scope_file_id,
@@ -312,6 +314,7 @@ def ask_stream():
                     try:
                         parsed = _json.loads(data_line[6:])
                         sources_payload = parsed.get("sources", [])
+                        chunk_citations = parsed.get("chunk_citations", [])
                         full_text_parts = [parsed.get("text", "")]
                     except Exception:
                         pass
@@ -319,7 +322,8 @@ def ask_stream():
         conv = Conversation.query.get(conv_id)
         if conv is not None:
             msg = conv_service.add_assistant_message(
-                conv, "".join(full_text_parts), sources_payload
+                conv, "".join(full_text_parts), sources_payload,
+                chunk_citations=chunk_citations,
             )
             events.log_event(
                 events.ASK_ANSWERED,

--- a/filenergy/views/dashboard.py
+++ b/filenergy/views/dashboard.py
@@ -13,11 +13,13 @@ from sqlalchemy import func
 from filenergy import db
 from filenergy.models import (
     ApiKey,
+    Chunk,
     Collection,
     Conversation,
     Event,
     File,
     Message,
+    MessageCitation,
     WorkspaceMember,
     utcnow,
 )
@@ -75,16 +77,33 @@ def index():
     uploads = _daily_counts("file.uploaded", ws_id)
     asks = _daily_counts("ask.question", ws_id)
 
-    # Top-asked files (by count of ask.question events that mentioned them).
+    # Most-cited files (real chunk-level provenance from MessageCitation).
     top_files = (
-        db.session.query(File.name, func.count(Event.id).label("hits"))
-        .join(Event, Event.workspace_id == File.workspace_id)
-        .filter(
-            File.workspace_id == ws_id,
-            Event.type == "ask.answered",
+        db.session.query(
+            File.id, File.name, File.url,
+            func.count(MessageCitation.id).label("hits"),
         )
+        .join(Chunk, Chunk.file_id == File.id)
+        .join(MessageCitation, MessageCitation.chunk_id == Chunk.id)
+        .filter(File.workspace_id == ws_id)
         .group_by(File.id)
-        .order_by(func.count(Event.id).desc())
+        .order_by(func.count(MessageCitation.id).desc())
+        .limit(5)
+        .all()
+    )
+
+    # Most-cited chunks across the workspace (with snippet for the dashboard).
+    top_chunks = (
+        db.session.query(
+            Chunk.id, Chunk.position, Chunk.content,
+            File.name, File.url,
+            func.count(MessageCitation.id).label("hits"),
+        )
+        .join(File, File.id == Chunk.file_id)
+        .join(MessageCitation, MessageCitation.chunk_id == Chunk.id)
+        .filter(File.workspace_id == ws_id)
+        .group_by(Chunk.id)
+        .order_by(func.count(MessageCitation.id).desc())
         .limit(5)
         .all()
     )
@@ -95,5 +114,6 @@ def index():
         uploads=uploads,
         asks=asks,
         top_files=top_files,
+        top_chunks=top_chunks,
         usage=billing.usage_summary(g.workspace),
     )

--- a/manage.py
+++ b/manage.py
@@ -1,9 +1,11 @@
 """Run with `flask --app manage run` or `python manage.py`.
 
 Usage:
-  python manage.py             # start the dev server
-  python manage.py reindex     # re-extract + re-embed every file
+  python manage.py                      # start the dev server
+  python manage.py reindex              # re-extract + re-embed every file
   python manage.py create-superuser EMAIL PASSWORD
+  python manage.py generate-encryption-key
+  python manage.py reencrypt            # back-fill at-rest encryption
 """
 from __future__ import annotations
 
@@ -38,6 +40,21 @@ def cmd_create_superuser(email: str, password: str):
         print(f"created superuser: {email}")
 
 
+def cmd_generate_encryption_key():
+    from filenergy.services import crypto
+    print(crypto.generate_key())
+
+
+def cmd_reencrypt():
+    from filenergy.services import crypto
+    with app.app_context():
+        if not crypto.is_configured():
+            print("FILENERGY_ENCRYPTION_KEY is not set; nothing to do.")
+            return
+        counts = crypto.reencrypt_all()
+        print(f"re-encrypted: {counts}")
+
+
 def main(argv: list[str]):
     if len(argv) < 2:
         app.run(debug=True, host="0.0.0.0", port=5000)
@@ -47,6 +64,10 @@ def main(argv: list[str]):
         cmd_reindex()
     elif cmd == "create-superuser":
         cmd_create_superuser(*rest)
+    elif cmd == "generate-encryption-key":
+        cmd_generate_encryption_key()
+    elif cmd == "reencrypt":
+        cmd_reencrypt()
     else:
         print(__doc__)
         sys.exit(1)

--- a/tests/test_connector_cursors.py
+++ b/tests/test_connector_cursors.py
@@ -1,0 +1,371 @@
+"""Tests for incremental sync via per-account cursors."""
+import json
+
+import pytest
+
+from filenergy.models import ConnectorAccount, File
+from filenergy.services import connectors
+
+
+def _stub(monkeypatch, responses):
+    class _R:
+        def __init__(self, body):
+            self._body = body if isinstance(body, bytes) else body.encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self, n=None):
+            return self._body if n is None else self._body[:n]
+
+    def fake(req, timeout=None):
+        for predicate, body in responses:
+            if predicate(req):
+                return _R(body)
+        raise RuntimeError(f"unexpected URL: {req.full_url}")
+
+    monkeypatch.setattr("urllib.request.urlopen", fake)
+
+
+# ---- Google Drive ----
+
+
+def test_drive_first_sync_persists_modified_time_cursor(
+    db, user, workspace, app, monkeypatch,
+):
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "x")
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "y")
+    a = ConnectorAccount(
+        workspace_id=workspace.id, kind="google_drive",
+        access_token="t", refresh_token=None,
+    )
+    db.session.add(a)
+    db.session.commit()
+
+    listing = {
+        "files": [
+            {"id": "f1", "name": "a.csv",
+             "mimeType": "text/csv",
+             "modifiedTime": "2026-04-30T10:00:00Z"},
+        ]
+    }
+    seen_urls: list[str] = []
+
+    def fake(req, timeout=None):
+        seen_urls.append(req.full_url)
+        body = (
+            json.dumps(listing) if "files?" in req.full_url and "alt" not in req.full_url
+            else b"col1,col2\n"
+        )
+
+        class R:
+            def __enter__(self): return self
+            def __exit__(self, *_): return False
+            def read(self, n=None):
+                return body if isinstance(body, bytes) else body.encode()
+
+        return R()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake)
+    with app.test_request_context():
+        connectors.get("google_drive").sync(a, user=user, workspace=workspace)
+
+    db.session.refresh(a)
+    assert a.sync_cursor == "2026-04-30T10:00:00Z"
+    # The first listing call had no q= filter.
+    assert not any("q=" in u for u in seen_urls)
+
+
+def test_drive_second_sync_uses_cursor_filter(db, user, workspace, app, monkeypatch):
+    """Second sync sends `q=modifiedTime > 'cursor'`."""
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "x")
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "y")
+    a = ConnectorAccount(
+        workspace_id=workspace.id, kind="google_drive",
+        access_token="t", refresh_token=None,
+        sync_cursor="2026-04-29T00:00:00Z",
+    )
+    db.session.add(a)
+    db.session.commit()
+
+    seen_urls: list[str] = []
+
+    def fake(req, timeout=None):
+        seen_urls.append(req.full_url)
+
+        class R:
+            def __enter__(self): return self
+            def __exit__(self, *_): return False
+            def read(self, n=None): return json.dumps({"files": []}).encode()
+
+        return R()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake)
+    with app.test_request_context():
+        connectors.get("google_drive").sync(a, user=user, workspace=workspace)
+    assert any(
+        "q=modifiedTime+%3E+%272026-04-29T00%3A00%3A00Z%27" in u
+        for u in seen_urls
+    )
+
+
+# ---- Notion ----
+
+
+def test_notion_sync_persists_next_cursor(db, user, workspace, app, monkeypatch):
+    a = ConnectorAccount(
+        workspace_id=workspace.id, kind="notion", access_token="secret_x",
+    )
+    db.session.add(a)
+    db.session.commit()
+    pages = {
+        "results": [{
+            "id": "p1",
+            "properties": {
+                "Name": {"type": "title",
+                         "title": [{"plain_text": "Page 1"}]},
+            },
+        }],
+        "next_cursor": "cursor-abc",
+    }
+    blocks = {"results": [
+        {"type": "paragraph",
+         "paragraph": {"rich_text": [{"plain_text": "hi"}]}},
+    ]}
+    _stub(monkeypatch, [
+        (lambda r: "search" in r.full_url, json.dumps(pages)),
+        (lambda r: "blocks" in r.full_url, json.dumps(blocks)),
+    ])
+    with app.test_request_context():
+        connectors.get("notion").sync(a, user=user, workspace=workspace)
+    db.session.refresh(a)
+    assert a.sync_cursor == "cursor-abc"
+
+
+def test_notion_clears_cursor_when_exhausted(db, user, workspace, app, monkeypatch):
+    """When `next_cursor` is null, we drop the cursor so the next tick starts over."""
+    a = ConnectorAccount(
+        workspace_id=workspace.id, kind="notion",
+        access_token="secret_x", sync_cursor="prev",
+    )
+    db.session.add(a)
+    db.session.commit()
+    _stub(monkeypatch, [
+        (lambda r: "search" in r.full_url,
+         json.dumps({"results": [], "next_cursor": None})),
+    ])
+    with app.test_request_context():
+        connectors.get("notion").sync(a, user=user, workspace=workspace)
+    db.session.refresh(a)
+    assert a.sync_cursor is None
+
+
+def test_notion_sync_uses_start_cursor_when_set(db, user, workspace, app, monkeypatch):
+    a = ConnectorAccount(
+        workspace_id=workspace.id, kind="notion",
+        access_token="secret_x", sync_cursor="cursor-xyz",
+    )
+    db.session.add(a)
+    db.session.commit()
+
+    captured: list = []
+
+    def fake(req, timeout=None):
+        captured.append(req.data or b"")
+
+        class R:
+            def __enter__(self): return self
+            def __exit__(self, *_): return False
+            def read(self, n=None):
+                return json.dumps({"results": [], "next_cursor": None}).encode()
+
+        return R()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake)
+    with app.test_request_context():
+        connectors.get("notion").sync(a, user=user, workspace=workspace)
+    body = json.loads(captured[0].decode())
+    assert body.get("start_cursor") == "cursor-xyz"
+
+
+# ---- Dropbox ----
+
+
+def test_dropbox_first_sync_persists_cursor(db, user, workspace, app, monkeypatch):
+    monkeypatch.setenv("DROPBOX_OAUTH_CLIENT_ID", "x")
+    monkeypatch.setenv("DROPBOX_OAUTH_CLIENT_SECRET", "y")
+    a = ConnectorAccount(
+        workspace_id=workspace.id, kind="dropbox",
+        access_token="t", refresh_token=None,
+    )
+    db.session.add(a)
+    db.session.commit()
+
+    listing = {
+        "entries": [],
+        "cursor": "dbx-cursor-1",
+    }
+    _stub(monkeypatch, [
+        (lambda r: "list_folder" in r.full_url and "continue" not in r.full_url,
+         json.dumps(listing)),
+    ])
+    with app.test_request_context():
+        connectors.get("dropbox").sync(a, user=user, workspace=workspace)
+    db.session.refresh(a)
+    assert a.sync_cursor == "dbx-cursor-1"
+
+
+def test_dropbox_second_sync_uses_continue_endpoint(
+    db, user, workspace, app, monkeypatch,
+):
+    monkeypatch.setenv("DROPBOX_OAUTH_CLIENT_ID", "x")
+    monkeypatch.setenv("DROPBOX_OAUTH_CLIENT_SECRET", "y")
+    a = ConnectorAccount(
+        workspace_id=workspace.id, kind="dropbox",
+        access_token="t", refresh_token=None,
+        sync_cursor="dbx-cursor-1",
+    )
+    db.session.add(a)
+    db.session.commit()
+    seen_urls: list[str] = []
+
+    def fake(req, timeout=None):
+        seen_urls.append(req.full_url)
+
+        class R:
+            def __enter__(self): return self
+            def __exit__(self, *_): return False
+            def read(self, n=None):
+                return json.dumps(
+                    {"entries": [], "cursor": "dbx-cursor-2"}
+                ).encode()
+
+        return R()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake)
+    with app.test_request_context():
+        connectors.get("dropbox").sync(a, user=user, workspace=workspace)
+    assert any("/continue" in u for u in seen_urls)
+    db.session.refresh(a)
+    assert a.sync_cursor == "dbx-cursor-2"
+
+
+# ---- Slack ----
+
+
+def test_slack_first_sync_uses_oldest_zero_and_saves_latest_ts(
+    db, user, workspace, app, monkeypatch,
+):
+    a = ConnectorAccount(
+        workspace_id=workspace.id, kind="slack", access_token="xoxb-t",
+    )
+    db.session.add(a)
+    db.session.commit()
+
+    channels = {"ok": True, "channels": [{"id": "C1", "name": "general"}]}
+    history = {"ok": True, "messages": [
+        {"user": "U1", "text": "hello", "ts": "1700000000.000100"},
+        {"user": "U2", "text": "world", "ts": "1700000010.000200"},
+    ]}
+    seen_oldest: list[str] = []
+
+    def fake(req, timeout=None):
+        if "conversations.history" in req.full_url:
+            # Capture the oldest= param.
+            from urllib.parse import urlparse, parse_qs
+            qs = parse_qs(urlparse(req.full_url).query)
+            seen_oldest.append(qs.get("oldest", [""])[0])
+
+        class R:
+            def __enter__(self): return self
+            def __exit__(self, *_): return False
+            def read(self, n=None):
+                if "conversations.list" in req.full_url:
+                    return json.dumps(channels).encode()
+                return json.dumps(history).encode()
+
+        return R()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake)
+    with app.test_request_context():
+        connectors.get("slack").sync(a, user=user, workspace=workspace)
+
+    assert seen_oldest == ["0"]
+    db.session.refresh(a)
+    assert a.sync_cursor == "1700000010.000200"
+
+
+def test_slack_second_sync_uses_saved_cursor(db, user, workspace, app, monkeypatch):
+    a = ConnectorAccount(
+        workspace_id=workspace.id, kind="slack",
+        access_token="xoxb-t", sync_cursor="1700000010.000200",
+    )
+    db.session.add(a)
+    db.session.commit()
+
+    channels = {"ok": True, "channels": [{"id": "C1", "name": "general"}]}
+    history = {"ok": True, "messages": []}
+    seen_oldest: list[str] = []
+
+    def fake(req, timeout=None):
+        if "conversations.history" in req.full_url:
+            from urllib.parse import urlparse, parse_qs
+            qs = parse_qs(urlparse(req.full_url).query)
+            seen_oldest.append(qs.get("oldest", [""])[0])
+
+        class R:
+            def __enter__(self): return self
+            def __exit__(self, *_): return False
+            def read(self, n=None):
+                if "conversations.list" in req.full_url:
+                    return json.dumps(channels).encode()
+                return json.dumps(history).encode()
+
+        return R()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake)
+    with app.test_request_context():
+        connectors.get("slack").sync(a, user=user, workspace=workspace)
+    assert seen_oldest == ["1700000010.000200"]
+
+
+def test_slack_appends_delta_to_existing_transcript(
+    db, user, workspace, app, monkeypatch,
+):
+    """When the channel's transcript file already exists, Slack appends."""
+    import os
+    from filenergy.services.file import FileService
+
+    # Pre-create the transcript file.
+    os.makedirs("/tmp/filenergy-slack-test", exist_ok=True)
+    path = "/tmp/filenergy-slack-test/slack-general.txt"
+    with open(path, "wb") as fd:
+        fd.write(b"old content")
+    f = File(
+        user_id=user.id, workspace_id=workspace.id,
+        name="slack-general.txt", path=path, url="szz",
+    )
+    db.session.add(f)
+    a = ConnectorAccount(
+        workspace_id=workspace.id, kind="slack", access_token="xoxb-t",
+    )
+    db.session.add(a)
+    db.session.commit()
+
+    channels = {"ok": True, "channels": [{"id": "C1", "name": "general"}]}
+    history = {"ok": True, "messages": [
+        {"user": "U1", "text": "new line", "ts": "1700000020.000300"},
+    ]}
+    _stub(monkeypatch, [
+        (lambda r: "conversations.list" in r.full_url, json.dumps(channels)),
+        (lambda r: "conversations.history" in r.full_url, json.dumps(history)),
+    ])
+    with app.test_request_context():
+        connectors.get("slack").sync(a, user=user, workspace=workspace)
+
+    body = open(path, "rb").read()
+    assert b"old content" in body
+    assert b"new line" in body

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,163 @@
+"""Tests for chunk-level provenance: MessageCitation rows + dashboard surface."""
+import json
+
+import pytest
+
+from filenergy.models import (
+    Chunk,
+    Conversation,
+    File,
+    Message,
+    MessageCitation,
+)
+from filenergy.services import conversations
+
+
+def _make_chunk(db, user, workspace, content="apples"):
+    f = File(
+        user_id=user.id, workspace_id=workspace.id,
+        name="note.txt", path="/x", url="hh",
+    )
+    db.session.add(f)
+    db.session.commit()
+    c = Chunk(
+        file_id=f.id, position=0, content=content,
+        embedding=json.dumps([1.0, 0.0, 0.0]),
+    )
+    db.session.add(c)
+    db.session.commit()
+    return c
+
+
+def test_add_assistant_message_persists_citations(db, user, workspace, app):
+    with app.test_request_context():
+        c = conversations.get_or_create(user, workspace, None)
+        chunk = _make_chunk(db, user, workspace)
+        msg = conversations.add_assistant_message(
+            c, "Apples are red.", [],
+            chunk_citations=[(chunk.id, 0.92)],
+        )
+    rows = MessageCitation.query.filter_by(message_id=msg.id).all()
+    assert len(rows) == 1
+    assert rows[0].chunk_id == chunk.id
+    assert abs(rows[0].score - 0.92) < 1e-6
+
+
+def test_add_assistant_message_skips_empty_citations(db, user, workspace, app):
+    with app.test_request_context():
+        c = conversations.get_or_create(user, workspace, None)
+        msg = conversations.add_assistant_message(c, "x", [], chunk_citations=[])
+    assert MessageCitation.query.count() == 0
+
+
+def test_add_assistant_message_skips_malformed_entries(db, user, workspace, app):
+    with app.test_request_context():
+        c = conversations.get_or_create(user, workspace, None)
+        chunk = _make_chunk(db, user, workspace)
+        msg = conversations.add_assistant_message(
+            c, "x", [],
+            # Mix of valid, malformed, and None — only the valid one survives.
+            chunk_citations=[
+                (chunk.id, 0.9),
+                "not-a-tuple",
+                (None, 0.5),
+                (chunk.id, "not-a-float"),  # ValueError on float() — skipped
+            ],
+        )
+    rows = MessageCitation.query.filter_by(message_id=msg.id).all()
+    assert len(rows) == 1
+    assert rows[0].chunk_id == chunk.id
+
+
+def test_chat_answer_question_returns_chunk_citations(
+    db, user, workspace, _stub_external_services
+):
+    from filenergy.services import chat
+
+    chunk = _make_chunk(db, user, workspace)
+    answer = chat.answer_question(workspace, "?")
+    assert answer.chunk_citations
+    chunk_ids = {c[0] for c in answer.chunk_citations}
+    assert chunk.id in chunk_ids
+
+
+def test_chat_no_results_returns_empty_citations(db, workspace, monkeypatch):
+    from filenergy.services import chat, embeddings
+
+    monkeypatch.setattr(embeddings, "search", lambda w, q, k, **kw: [])
+    answer = chat.answer_question(workspace, "?")
+    assert answer.chunk_citations == []
+
+
+def test_stream_answer_done_event_includes_chunk_citations(
+    db, user, workspace, _stub_external_services
+):
+    from filenergy.services import chat
+
+    _make_chunk(db, user, workspace)
+    events = list(chat.stream_answer(workspace, "?"))
+    done = [e for e in events if e.startswith("event: done")]
+    assert done
+    payload = json.loads(done[-1].split("data: ", 1)[1])
+    assert "chunk_citations" in payload
+
+
+def test_ask_view_persists_citations_e2e(auth_client, db, user, workspace,
+                                           _stub_external_services):
+    """Full path: POST /ask/ → MessageCitation rows show up."""
+    chunk = _make_chunk(db, user, workspace)
+    r = auth_client.post("/ask/", json={"question": "?"})
+    assert r.status_code == 200
+    assert MessageCitation.query.count() >= 1
+    assert MessageCitation.query.first().chunk_id == chunk.id
+
+
+def test_ask_stream_view_persists_citations(auth_client, db, user, workspace,
+                                              _stub_external_services):
+    chunk = _make_chunk(db, user, workspace)
+    r = auth_client.post("/ask/stream", json={"question": "?"})
+    assert r.status_code == 200
+    # SSE consumer drains the body — done by the test client implicitly.
+    r.get_data()
+    assert MessageCitation.query.count() >= 1
+
+
+def test_dashboard_surfaces_top_chunks(auth_client, db, user, workspace,
+                                         _stub_external_services):
+    chunk = _make_chunk(db, user, workspace, content="alpha bravo charlie delta")
+    auth_client.post("/ask/", json={"question": "?"})
+    r = auth_client.get("/dashboard/")
+    assert r.status_code == 200
+    assert b"Most-cited chunks" in r.data
+    assert b"alpha bravo" in r.data
+
+
+def test_dashboard_handles_no_citations(auth_client):
+    """Dashboard renders even when there are zero citations yet."""
+    r = auth_client.get("/dashboard/")
+    assert r.status_code == 200
+
+
+def test_chunk_deletion_cascades_citations(db, user, workspace, app):
+    with app.test_request_context():
+        chunk = _make_chunk(db, user, workspace)
+        c = conversations.get_or_create(user, workspace, None)
+        msg = conversations.add_assistant_message(
+            c, "x", [], chunk_citations=[(chunk.id, 0.9)]
+        )
+        assert MessageCitation.query.count() == 1
+        db.session.delete(chunk)
+        db.session.commit()
+    assert MessageCitation.query.count() == 0
+
+
+def test_message_deletion_cascades_citations(db, user, workspace, app):
+    with app.test_request_context():
+        chunk = _make_chunk(db, user, workspace)
+        c = conversations.get_or_create(user, workspace, None)
+        msg = conversations.add_assistant_message(
+            c, "x", [], chunk_citations=[(chunk.id, 0.9)]
+        )
+        db.session.delete(msg)
+        db.session.commit()
+    assert MessageCitation.query.count() == 0

--- a/tests/test_services_connectors_extra.py
+++ b/tests/test_services_connectors_extra.py
@@ -579,7 +579,7 @@ def test_slack_channel_transcript_history_failure(monkeypatch):
 
     monkeypatch.setattr("urllib.request.urlopen", boom)
     from filenergy.services.connectors import _slack_channel_transcript
-    assert _slack_channel_transcript("C", {"Authorization": "x"}, 100) == ""
+    assert _slack_channel_transcript("C", {"Authorization": "x"}, 100) == ("", "")
 
 
 def test_slack_channel_transcript_not_ok(monkeypatch):
@@ -588,4 +588,4 @@ def test_slack_channel_transcript_not_ok(monkeypatch):
         (lambda r: True, json.dumps({"ok": False, "error": "rate_limited"})),
     ])
     from filenergy.services.connectors import _slack_channel_transcript
-    assert _slack_channel_transcript("C", {"Authorization": "x"}, 100) == ""
+    assert _slack_channel_transcript("C", {"Authorization": "x"}, 100) == ("", "")

--- a/tests/test_services_crypto.py
+++ b/tests/test_services_crypto.py
@@ -1,0 +1,158 @@
+"""Tests for at-rest encryption (services/crypto.py + EncryptedText)."""
+import os
+
+import pytest
+
+from filenergy.services import crypto
+
+
+def test_is_configured_false_default(monkeypatch):
+    monkeypatch.delenv("FILENERGY_ENCRYPTION_KEY", raising=False)
+    assert crypto.is_configured() is False
+
+
+def test_is_configured_true_with_env(monkeypatch):
+    monkeypatch.setenv("FILENERGY_ENCRYPTION_KEY", crypto.generate_key())
+    assert crypto.is_configured() is True
+
+
+def test_encrypt_passthrough_when_unconfigured(monkeypatch):
+    monkeypatch.delenv("FILENERGY_ENCRYPTION_KEY", raising=False)
+    assert crypto.encrypt("hello") == "hello"
+    assert crypto.encrypt(None) is None
+
+
+def test_decrypt_passthrough_when_unconfigured(monkeypatch):
+    monkeypatch.delenv("FILENERGY_ENCRYPTION_KEY", raising=False)
+    assert crypto.decrypt("plaintext") == "plaintext"
+    assert crypto.decrypt(None) is None
+
+
+def test_roundtrip_with_key(monkeypatch):
+    monkeypatch.setenv("FILENERGY_ENCRYPTION_KEY", crypto.generate_key())
+    enc = crypto.encrypt("a secret")
+    assert enc.startswith("enc:")
+    assert enc != "a secret"
+    assert crypto.decrypt(enc) == "a secret"
+
+
+def test_idempotent_encrypt(monkeypatch):
+    """Encrypting an already-encrypted value is a no-op."""
+    monkeypatch.setenv("FILENERGY_ENCRYPTION_KEY", crypto.generate_key())
+    enc = crypto.encrypt("secret")
+    assert crypto.encrypt(enc) == enc
+
+
+def test_decrypt_passthrough_for_plaintext_when_keyed(monkeypatch):
+    """Mixed-encryption tables: plaintext rows still round-trip."""
+    monkeypatch.setenv("FILENERGY_ENCRYPTION_KEY", crypto.generate_key())
+    assert crypto.decrypt("not-encrypted") == "not-encrypted"
+
+
+def test_decrypt_with_bad_key_returns_value(monkeypatch, caplog):
+    """If the key is rotated and we have a stale token, surface it instead
+    of raising — operators can spot the failure in logs."""
+    monkeypatch.setenv("FILENERGY_ENCRYPTION_KEY", crypto.generate_key())
+    encrypted = crypto.encrypt("hi")
+    monkeypatch.setenv("FILENERGY_ENCRYPTION_KEY", crypto.generate_key())
+    with caplog.at_level("ERROR", logger="filenergy.services.crypto"):
+        out = crypto.decrypt(encrypted)
+    assert out == encrypted  # unchanged; garbled output not silently emitted
+
+
+def test_decrypt_when_key_disappeared_logs_error(monkeypatch, caplog):
+    monkeypatch.setenv("FILENERGY_ENCRYPTION_KEY", crypto.generate_key())
+    encrypted = crypto.encrypt("hi")
+    monkeypatch.delenv("FILENERGY_ENCRYPTION_KEY", raising=False)
+    with caplog.at_level("ERROR", logger="filenergy.services.crypto"):
+        out = crypto.decrypt(encrypted)
+    assert out == encrypted
+    assert any("FILENERGY_ENCRYPTION_KEY" in r.message for r in caplog.records)
+
+
+def test_generate_key_format():
+    key = crypto.generate_key()
+    assert isinstance(key, str)
+    # Fernet keys are 32 url-safe base64 bytes (44 chars including '=').
+    assert len(key) == 44
+
+
+# ---- EncryptedText through SQLAlchemy ----
+
+
+def test_encrypted_column_roundtrip_with_key(db, user, workspace, app, monkeypatch):
+    """File.text_content writes encrypted, reads back plaintext."""
+    monkeypatch.setenv("FILENERGY_ENCRYPTION_KEY", crypto.generate_key())
+    from filenergy.models import File
+
+    f = File(
+        user_id=user.id, workspace_id=workspace.id,
+        name="x.txt", path="/x", url="hh",
+        text_content="my secret notes",
+    )
+    db.session.add(f)
+    db.session.commit()
+    db.session.expire_all()
+
+    # Read back through the ORM — auto-decrypted.
+    fresh = File.query.first()
+    assert fresh.text_content == "my secret notes"
+
+    # Read raw row to confirm the on-disk value really is enc:...
+    row = db.session.execute(
+        db.text("SELECT text_content FROM file WHERE id=:id"), {"id": f.id}
+    ).first()
+    assert row[0].startswith("enc:")
+
+
+def test_encrypted_column_passthrough_without_key(db, user, workspace, app, monkeypatch):
+    monkeypatch.delenv("FILENERGY_ENCRYPTION_KEY", raising=False)
+    from filenergy.models import File
+
+    f = File(
+        user_id=user.id, workspace_id=workspace.id,
+        name="x.txt", path="/x", url="hh",
+        text_content="plain",
+    )
+    db.session.add(f)
+    db.session.commit()
+    row = db.session.execute(
+        db.text("SELECT text_content FROM file WHERE id=:id"), {"id": f.id}
+    ).first()
+    assert row[0] == "plain"
+
+
+def test_reencrypt_all_walks_columns(db, user, workspace, app, monkeypatch):
+    """Pre-existing plaintext rows get re-written through the encrypted type."""
+    monkeypatch.delenv("FILENERGY_ENCRYPTION_KEY", raising=False)
+    from filenergy.models import ConnectorAccount, File
+
+    f = File(
+        user_id=user.id, workspace_id=workspace.id,
+        name="x.txt", path="/x", url="hh",
+        text_content="plain notes",
+    )
+    a = ConnectorAccount(
+        workspace_id=workspace.id, kind="google_drive",
+        access_token="plain-token", refresh_token="plain-refresh",
+    )
+    db.session.add_all([f, a])
+    db.session.commit()
+
+    # Now flip encryption on and back-fill.
+    monkeypatch.setenv("FILENERGY_ENCRYPTION_KEY", crypto.generate_key())
+    counts = crypto.reencrypt_all()
+    assert counts["file"] >= 1
+    assert counts["connector_account"] >= 1
+
+    raw = db.session.execute(
+        db.text("SELECT text_content FROM file WHERE id=:id"), {"id": f.id}
+    ).first()
+    assert raw[0].startswith("enc:")
+    assert File.query.first().text_content == "plain notes"
+
+
+def test_reencrypt_all_noop_without_key(db, monkeypatch):
+    monkeypatch.delenv("FILENERGY_ENCRYPTION_KEY", raising=False)
+    counts = crypto.reencrypt_all()
+    assert counts == {"file": 0, "chunk": 0, "connector_account": 0, "user": 0}


### PR DESCRIPTION
Three roadmap items from PR #2:

**Encryption at rest** (`services/crypto.py`)
- Fernet-backed `EncryptedText` SQLAlchemy type
- Wraps `File.text_content`, `Chunk.embedding`, `ConnectorAccount.access_token` + `refresh_token`, `User.totp_secret`
- Activated by `FILENERGY_ENCRYPTION_KEY`; round-trips plaintext without it (back-compat)
- `enc:` prefix lets old plaintext + new encrypted rows coexist during rollout
- `python manage.py generate-encryption-key` + `python manage.py reencrypt`

**Chunk-level provenance** (`MessageCitation`)
- Every assistant turn writes one `MessageCitation` per retrieved chunk + cosine score
- Dashboard has a real "Most-cited chunks" panel with snippet preview
- "Most-cited files" panel now uses citation counts (was proxying via `ask.answered` events before)

**Incremental connector sync** (`ConnectorAccount.sync_cursor`)
- Drive: `q=modifiedTime > '<RFC3339>'`
- Notion: `start_cursor` / `next_cursor`
- Dropbox: `list_folder/continue` (delta-native)
- Slack: `oldest=<ts>`; deltas append to per-channel transcript file

## Test plan

- [x] `python -m pytest --cov` — 650 passing, 97.5% coverage
- [x] EncryptedText round-trip with + without key
- [x] `reencrypt` back-fills existing plaintext rows
- [x] MessageCitation cascades on Chunk + Message delete
- [x] First-sync vs cursored-sync paths for each connector

https://claude.ai/code/session_01V5mfhSQRZzyNxdsNx1ybWN

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5mfhSQRZzyNxdsNx1ybWN)_