### PR TITLE
Drop dead imports + ship the missing Alembic migration

### DIFF
--- a/filenergy/services/billing.py
+++ b/filenergy/services/billing.py
@@ -8,10 +8,9 @@ work since they're DB-only.
 from __future__ import annotations
 
 import logging
-from typing import Optional
 
 from filenergy import db, settings
-from filenergy.models import Event, File, Workspace, utcnow
+from filenergy.models import Event, File, Workspace
 
 log = logging.getLogger(__name__)
 

--- a/filenergy/services/file.py
+++ b/filenergy/services/file.py
@@ -2,7 +2,6 @@ import hashlib
 import json
 import logging
 import os
-import threading
 
 from filenergy import app, db, settings
 from filenergy.models import Chunk, File, utcnow

--- a/filenergy/services/ingestion.py
+++ b/filenergy/services/ingestion.py
@@ -12,7 +12,6 @@ import os
 import re
 import threading
 from html.parser import HTMLParser
-from typing import BinaryIO
 from urllib import error as urllib_error
 from urllib import request as urllib_request
 from urllib.parse import urlparse

--- a/filenergy/services/pgvector_store.py
+++ b/filenergy/services/pgvector_store.py
@@ -20,10 +20,8 @@ import json
 import logging
 from typing import Any
 
-import numpy as np
-
 from filenergy import db
-from filenergy.models import Chunk, File
+from filenergy.models import Chunk
 
 log = logging.getLogger(__name__)
 

--- a/filenergy/views/onboarding.py
+++ b/filenergy/views/onboarding.py
@@ -59,14 +59,12 @@ def index():
 @login_required
 def seed():
     """Drop the sample files into the workspace and index them."""
+    import os
+    from filenergy import settings as cfg
+
+    os.makedirs(cfg.UPLOAD_DIR, exist_ok=True)
     svc = FileService()
     for name, body in _SAMPLE_FILES:
-        # Reuse the same upload code path as a real upload.
-        from filenergy.views.file import file_bp  # noqa: F401  ensure import order
-        # Synthesize a request-like; easier to call _persist_upload directly.
-        import os
-        from filenergy import settings as cfg
-        os.makedirs(cfg.UPLOAD_DIR, exist_ok=True)
         path = os.path.join(cfg.UPLOAD_DIR, f"sample-{name}")
         with open(path, "wb") as fd:
             fd.write(body)

--- a/migrations/versions/0aba938134d5_connectors_citations_2fa.py
+++ b/migrations/versions/0aba938134d5_connectors_citations_2fa.py
@@ -1,0 +1,101 @@
+"""connectors, message citations, encrypted totp_secret
+
+Revision ID: 0aba938134d5
+Revises: 886d0d241620
+Create Date: 2026-04-30 20:01:15.784676
+
+Adds tables and column-type changes that landed after the initial
+schema:
+
+  * `connector_account` — Notion/Slack/Dropbox/Drive OAuth state, plus
+    the per-account `sync_cursor` for incremental sync.
+  * `message_citation` — chunk-level provenance index pointing each
+    assistant Message at the Chunks it cited.
+  * `user.totp_secret` — was `VARCHAR(64)`; widened to `Text` so the
+    `enc:` prefix from `EncryptedText` fits.
+
+`access_token` / `refresh_token` / `embedding` / `text_content` are
+declared `EncryptedText` in the model but stored as plain `Text` on
+disk (the `enc:` prefix is the only on-disk difference). The
+migration uses `sa.Text()` to keep the schema portable across
+Postgres / SQLite.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0aba938134d5'
+down_revision = '886d0d241620'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'connector_account',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('workspace_id', sa.Integer(), nullable=True),
+        sa.Column('kind', sa.String(length=32), nullable=True),
+        sa.Column('account_label', sa.String(length=255), nullable=True),
+        sa.Column('access_token', sa.Text(), nullable=True),
+        sa.Column('refresh_token', sa.Text(), nullable=True),
+        sa.Column('sync_cursor', sa.Text(), nullable=True),
+        sa.Column('expires_at', sa.DateTime(), nullable=True),
+        sa.Column('last_synced_at', sa.DateTime(), nullable=True),
+        sa.Column('last_error', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['workspace_id'], ['workspace.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        op.f('ix_connector_account_kind'),
+        'connector_account', ['kind'], unique=False,
+    )
+    op.create_index(
+        op.f('ix_connector_account_workspace_id'),
+        'connector_account', ['workspace_id'], unique=False,
+    )
+
+    op.create_table(
+        'message_citation',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('message_id', sa.Integer(), nullable=True),
+        sa.Column('chunk_id', sa.Integer(), nullable=True),
+        sa.Column('score', sa.Float(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['chunk_id'], ['chunk.id']),
+        sa.ForeignKeyConstraint(['message_id'], ['message.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        op.f('ix_message_citation_chunk_id'),
+        'message_citation', ['chunk_id'], unique=False,
+    )
+    op.create_index(
+        op.f('ix_message_citation_message_id'),
+        'message_citation', ['message_id'], unique=False,
+    )
+
+    with op.batch_alter_table('user') as batch:
+        batch.alter_column(
+            'totp_secret',
+            existing_type=sa.VARCHAR(length=64),
+            type_=sa.Text(),
+            existing_nullable=True,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('user') as batch:
+        batch.alter_column(
+            'totp_secret',
+            existing_type=sa.Text(),
+            type_=sa.VARCHAR(length=64),
+            existing_nullable=True,
+        )
+    op.drop_index(op.f('ix_message_citation_message_id'), table_name='message_citation')
+    op.drop_index(op.f('ix_message_citation_chunk_id'), table_name='message_citation')
+    op.drop_table('message_citation')
+    op.drop_index(op.f('ix_connector_account_workspace_id'), table_name='connector_account')
+    op.drop_index(op.f('ix_connector_account_kind'), table_name='connector_account')
+    op.drop_table('connector_account')


### PR DESCRIPTION
Found while doing a coherence sweep across the codebase.

## Schema drift

`connector_account`, `message_citation`, and the `user.totp_secret` widening (was `VARCHAR(64)`, became `Text` to fit the `enc:` prefix) shipped without Alembic migrations. Production deploys via `flask db upgrade` would have been missing those tables.

This PR adds revision `0aba938134d5` so the DAG matches the live schema. Portable `sa.Text()` for the `EncryptedText` columns since the on-disk shape is plain text — only the prefix differs at the application layer.

After applying: `flask db migrate` produces an empty diff, confirming no further drift.

## Dead imports

- `services/file.py`: stray `import threading` (replaced by `jobs.enqueue`)
- `services/billing.py`: `Optional`, `utcnow`
- `services/pgvector_store.py`: `numpy`, `File`
- `services/ingestion.py`: `BinaryIO`
- `views/onboarding.py`: a `noqa`-flagged `from filenergy.views.file import file_bp` that existed only as a comment about import ordering

## Test plan

- [x] 650 tests still pass at 97.5% coverage
- [x] `flask db upgrade` against a fresh SQLite — both revisions apply cleanly
- [x] `flask db migrate` after upgrade produces a no-op revision (no drift)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5mfhSQRZzyNxdsNx1ybWN)_