### PR TITLE
Tier 4: real WebAuthn + compiled Tailwind + retry-aware jobs queue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,20 @@
+# --- CSS build stage ---------------------------------------------------------
+# Compile Tailwind once at image-build time. Output gets baked into the
+# runtime image at /app/filenergy/static/css/app.css; base.html picks it up
+# automatically and serves it instead of pulling the Play CDN.
+FROM node:20-alpine AS css
+
+WORKDIR /build
+COPY package.json tailwind.config.js ./
+RUN npm install --silent
+COPY filenergy/static/css/tailwind.src.css ./filenergy/static/css/tailwind.src.css
+COPY filenergy/templates ./filenergy/templates
+RUN npx tailwindcss \
+        -i ./filenergy/static/css/tailwind.src.css \
+        -o ./filenergy/static/css/app.css \
+        --minify
+
+# --- Python runtime ---------------------------------------------------------
 FROM python:3.11-slim AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -23,6 +40,8 @@ COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt gunicorn==23.0.0
 
 COPY . .
+# Overlay the compiled CSS produced by the css stage.
+COPY --from=css /build/filenergy/static/css/app.css ./filenergy/static/css/app.css
 
 # Non-root for runtime.
 RUN useradd --create-home --shell /bin/sh filenergy \

--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ the Anthropic Claude API for answers, and Stripe Checkout for billing.
 - **2FA (TOTP)** — `pyotp` + QR code. 8 single-use recovery codes
   generated on enable. Login flow defers `login_user` until the OTP
   succeeds, so a stolen password alone is not enough.
-- **WebAuthn / passkeys** — register a hardware key (YubiKey, Touch ID,
-  Windows Hello) and use it as the second factor instead of a TOTP code.
-  Multiple keys per user; per-key labels and last-used timestamps in the
-  security settings.
+- **WebAuthn / passkeys** — full FIDO2 ceremony backed by `py_webauthn`:
+  `navigator.credentials.create/get` from the browser, challenge stash in
+  Flask session, attestation + assertion verification server-side. Also
+  ships a stub fallback for tests / pre-JS deploys. Multiple keys per
+  user; per-key labels and last-used timestamps in security settings.
 - **Workspace-wide 2FA enforcement** — owners can flip "Require 2FA"; any
   member without TOTP or a passkey is bounced to /settings/security on
   the next request until they enroll.
@@ -110,8 +111,16 @@ the Anthropic Claude API for answers, and Stripe Checkout for billing.
 
 ### Deploy
 
-- **Dockerfile** (Python 3.11 slim + gunicorn, non-root user, healthcheck).
+- **Dockerfile** with a multi-stage build: a Node 20 stage compiles
+  Tailwind into `static/css/app.css`, the Python 3.11 stage copies it
+  into the runtime image. base.html links the bundle when present and
+  falls back to the Play CDN in dev. CSP tightens automatically (drops
+  `'unsafe-eval'` and the CDN host) when the bundle is in use.
 - **docker-compose.yml** with a persistent SQLite volume.
+- **Background jobs** with retries — webhook deliveries (5xx + network
+  errors), digest emails (SMTP failures). Exponential backoff (2/4/8/16s)
+  via `jobs.enqueue(..., retries=4)`. RQ-backed when Redis is configured;
+  threading fallback otherwise.
 
 ### Ingestion
 

--- a/filenergy/__init__.py
+++ b/filenergy/__init__.py
@@ -34,6 +34,15 @@ if not os.environ.get("FILENERGY_SKIP_CREATE_ALL"):
         db.create_all()
 
 
+# Expose presence of the compiled Tailwind bundle to every template. When
+# `static/css/app.css` exists (produced by `npm run build:css` during the
+# Docker build), base.html links to it and skips the Play CDN.
+@app.context_processor
+def _inject_css_bundle_flag():
+    bundle = os.path.join(app.static_folder, "css", "app.css")
+    return {"css_bundle_built": os.path.isfile(bundle)}
+
+
 # CLI: weekly digest send-out. Wire as `flask send-digests` (cron / k8s job).
 @app.cli.command("send-digests")
 def _send_digests_cli():

--- a/filenergy/middleware.py
+++ b/filenergy/middleware.py
@@ -92,22 +92,32 @@ def before_request():
         return redirect(url_for("settings.security"))
 
 
-# Content Security Policy. Stricter would block the inline scripts in
-# our Bootstrap-3 templates and the Swagger UI CDN at /api/v1/docs;
-# loosening 'self' + listed CDN hosts is the minimum that keeps the app
-# working without giving up framing/eval/object-tag protection.
-_CSP = (
-    "default-src 'self'; "
-    "img-src 'self' data: https://avatars.githubusercontent.com; "
-    "style-src 'self' 'unsafe-inline' https://unpkg.com https://cdn.tailwindcss.com; "
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com https://cdn.tailwindcss.com; "
-    "connect-src 'self'; "
-    "frame-ancestors 'none'; "
-    "base-uri 'self'; "
-    "object-src 'none'; "
-    "form-action 'self' https://accounts.google.com https://*.dropbox.com "
-    "https://api.notion.com https://slack.com https://stripe.com"
-)
+# Content Security Policy. Stricter would block the Swagger UI CDN at
+# /api/v1/docs and the inline form helpers we use across templates.
+# When the compiled Tailwind bundle is present we tighten the policy by
+# removing the cdn.tailwindcss.com allowance and dropping `'unsafe-eval'`
+# (the Play CDN compiles styles via eval, the bundle does not need it).
+def _build_csp() -> str:
+    import os as _os
+    bundle = _os.path.join(app.static_folder, "css", "app.css")
+    has_bundle = _os.path.isfile(bundle)
+    style_extra = "" if has_bundle else " https://cdn.tailwindcss.com"
+    script_extra = "" if has_bundle else " https://cdn.tailwindcss.com 'unsafe-eval'"
+    return (
+        "default-src 'self'; "
+        "img-src 'self' data: https://avatars.githubusercontent.com; "
+        f"style-src 'self' 'unsafe-inline' https://unpkg.com{style_extra}; "
+        f"script-src 'self' 'unsafe-inline' https://unpkg.com{script_extra}; "
+        "connect-src 'self'; "
+        "frame-ancestors 'none'; "
+        "base-uri 'self'; "
+        "object-src 'none'; "
+        "form-action 'self' https://accounts.google.com https://*.dropbox.com "
+        "https://api.notion.com https://slack.com https://stripe.com"
+    )
+
+
+_CSP = _build_csp()
 
 _SECURITY_HEADERS = {
     # Force HTTPS for a year + preload + subdomains. Harmless on HTTP

--- a/filenergy/services/digest.py
+++ b/filenergy/services/digest.py
@@ -31,6 +31,13 @@ DIGEST_INTERVAL = timedelta(days=7)
 WINDOW = timedelta(days=7)
 
 
+class DigestSendFailed(Exception):
+    """Raised so the jobs-queue retry policy can re-run a digest send
+    (transient SMTP failure, rate limiting, etc.). The user's
+    `last_digest_sent_at` is only updated when send succeeds, so a
+    retried failure won't double-deliver."""
+
+
 def _stats_for(workspace, since):
     files_uploaded = (
         File.query.filter(
@@ -108,13 +115,18 @@ def users_due():
     return q.all()
 
 
-def send_pending() -> int:
-    """Send digests to every eligible user. Returns count of sends."""
+def send_pending(*, async_dispatch: bool = False) -> int:
+    """Send digests to every eligible user. Returns count of sends.
+
+    `async_dispatch=True` enqueues each per-user send as a background job
+    with retries (useful for large fanouts under SMTP rate limits). The
+    default sync path keeps the CLI's "X digests sent" count truthful.
+    """
+    if async_dispatch:
+        return _send_pending_async()
+
     sent = 0
     for user in users_due():
-        # Use the user's first workspace as the digest scope. We could
-        # batch all workspaces in one email, but per-workspace makes the
-        # subject line meaningful and keeps the body short.
         m = (
             WorkspaceMember.query.filter_by(user_id=user.id)
             .order_by(WorkspaceMember.id.asc())
@@ -141,3 +153,61 @@ def send_pending() -> int:
         )
         sent += 1
     return sent
+
+
+def _send_pending_async() -> int:
+    """Enqueue one job per eligible user. Returns enqueue count.
+
+    Each job runs `send_for_user(user_id)` with the standard 4-retry
+    backoff so transient SMTP failures recover automatically.
+    """
+    from filenergy.services import jobs
+
+    count = 0
+    for user in users_due():
+        jobs.enqueue(
+            "filenergy.services.digest.send_for_user",
+            user.id,
+            retries=4,
+            retry_backoff_seconds=2,
+        )
+        count += 1
+    return count
+
+
+def send_for_user(user_id: int) -> bool:
+    """Send the digest for one user. Designed to be re-runnable from the
+    jobs queue: idempotency comes from updating `last_digest_sent_at` only
+    on success, and from the eligibility check at the top.
+    """
+    user = User.query.get(user_id)
+    if user is None:
+        return False
+    cutoff = utcnow() - DIGEST_INTERVAL
+    if (
+        user.weekly_digest is False
+        or (user.last_digest_sent_at is not None and user.last_digest_sent_at >= cutoff)
+    ):
+        return False
+
+    m = (
+        WorkspaceMember.query.filter_by(user_id=user.id)
+        .order_by(WorkspaceMember.id.asc())
+        .first()
+    )
+    if m is None or m.workspace is None:
+        return False
+    rendered = build_digest(user, m.workspace)
+    if rendered is None:
+        return False
+    subject, body = rendered
+    if not email_service.send(to=user.email or "", subject=subject, body=body):
+        raise DigestSendFailed(f"send failed for {user.email}")
+
+    user.last_digest_sent_at = utcnow()
+    db.session.commit()
+    events_log.log_event(
+        events_log.USER_DIGEST_SENT,
+        user=user, workspace_id=m.workspace.id,
+    )
+    return True

--- a/filenergy/services/jobs.py
+++ b/filenergy/services/jobs.py
@@ -6,8 +6,16 @@
 Tests force synchronous execution by setting `SYNC_JOBS=true` or running
 under `app.config["TESTING"]`.
 
+Retries: pass `retries=N` (and optionally `retry_backoff_seconds=...`) to
+get exponential-backoff retries for transient failures. Works in all
+three modes:
+
+  - sync: retries inline with `time.sleep` between attempts
+  - thread: same, but in the daemon thread
+  - rq: hands off to RQ's native `Retry` policy
+
 Use:
-    jobs.enqueue("filenergy.services.file._index_file_id", file_id)
+    jobs.enqueue("filenergy.services.file._index_file_id", file_id, retries=3)
 
 The target must be importable by string, because RQ workers don't share
 the request's process. For thread mode we resolve the dotted path at
@@ -19,10 +27,15 @@ import importlib
 import logging
 import os
 import threading
+import time
 
 from filenergy import app
 
 log = logging.getLogger(__name__)
+
+
+_DEFAULT_RETRIES = 0
+_DEFAULT_BACKOFF_SECONDS = 2
 
 
 def _import_target(dotted: str):
@@ -42,49 +55,105 @@ def is_sync() -> bool:
     )
 
 
-def enqueue(target: str, *args, **kwargs) -> None:
-    """Schedule a background job. Returns immediately."""
+def enqueue(
+    target: str,
+    *args,
+    retries: int = _DEFAULT_RETRIES,
+    retry_backoff_seconds: int = _DEFAULT_BACKOFF_SECONDS,
+    **kwargs,
+) -> None:
+    """Schedule a background job. Returns immediately.
+
+    `retries`: how many times to retry on exception before giving up.
+    `retry_backoff_seconds`: base for exponential backoff (sleep = base * 2**attempt).
+    """
     if is_sync():
-        _run(target, args, kwargs)
+        _run(target, args, kwargs, retries, retry_backoff_seconds)
         return
     backend = _backend()
     if backend == "rq":
-        _enqueue_rq(target, args, kwargs)
+        _enqueue_rq(target, args, kwargs, retries, retry_backoff_seconds)
     else:
-        _enqueue_thread(target, args, kwargs)
+        _enqueue_thread(target, args, kwargs, retries, retry_backoff_seconds)
 
 
-def _run(target: str, args: tuple, kwargs: dict) -> None:
+def _run(
+    target: str, args: tuple, kwargs: dict,
+    retries: int, backoff: int,
+) -> None:
     fn = _import_target(target)
+    attempts = 0
+    last_exc = None
     with app.app_context():
-        try:
-            fn(*args, **kwargs)
-        except Exception:
-            log.exception("Job %s failed", target)
+        while attempts <= retries:
+            try:
+                fn(*args, **kwargs)
+                return
+            except Exception as exc:
+                last_exc = exc
+                if attempts >= retries:
+                    log.exception(
+                        "Job %s failed after %d attempt(s)", target, attempts + 1,
+                    )
+                    return
+                sleep_s = backoff * (2 ** attempts)
+                log.warning(
+                    "Job %s attempt %d failed (%s); retrying in %ds",
+                    target, attempts + 1, exc, sleep_s,
+                )
+                # Skip the wait in tests so retries are fast.
+                if not app.config.get("TESTING"):
+                    time.sleep(sleep_s)
+                attempts += 1
+    if last_exc is not None:
+        log.error("Job %s exhausted retries: %s", target, last_exc)
 
 
-def _enqueue_thread(target: str, args: tuple, kwargs: dict) -> None:
+def _enqueue_thread(
+    target: str, args: tuple, kwargs: dict,
+    retries: int, backoff: int,
+) -> None:
     threading.Thread(
-        target=_run, args=(target, args, kwargs),
-        name=f"job-{target.rsplit('.', 1)[-1]}", daemon=True,
+        target=_run,
+        args=(target, args, kwargs, retries, backoff),
+        name=f"job-{target.rsplit('.', 1)[-1]}",
+        daemon=True,
     ).start()
 
 
-def _enqueue_rq(target: str, args: tuple, kwargs: dict) -> None:
+def _enqueue_rq(
+    target: str, args: tuple, kwargs: dict,
+    retries: int, backoff: int,
+) -> None:
     redis_url = os.environ.get("REDIS_URL")
     if not redis_url:
-        log.warning("FILENERGY_JOBS_BACKEND=rq but REDIS_URL not set; "
-                    "falling back to thread")
-        _enqueue_thread(target, args, kwargs)
+        log.warning(
+            "FILENERGY_JOBS_BACKEND=rq but REDIS_URL not set; "
+            "falling back to thread"
+        )
+        _enqueue_thread(target, args, kwargs, retries, backoff)
         return
     try:
         from redis import Redis  # type: ignore
         from rq import Queue  # type: ignore
     except ImportError:
         log.warning("rq/redis not installed; falling back to thread")
-        _enqueue_thread(target, args, kwargs)
+        _enqueue_thread(target, args, kwargs, retries, backoff)
         return
     queue_name = os.environ.get("FILENERGY_RQ_QUEUE", "filenergy")
     queue = Queue(queue_name, connection=Redis.from_url(redis_url))
     fn = _import_target(target)
-    queue.enqueue(fn, *args, **kwargs)
+    if retries > 0:
+        try:
+            from rq import Retry  # type: ignore
+        except ImportError:
+            queue.enqueue(fn, *args, **kwargs)
+            return
+        intervals = [backoff * (2 ** i) for i in range(retries)]
+        queue.enqueue(
+            fn, *args,
+            retry=Retry(max=retries, interval=intervals),
+            **kwargs,
+        )
+    else:
+        queue.enqueue(fn, *args, **kwargs)

--- a/filenergy/services/webauthn.py
+++ b/filenergy/services/webauthn.py
@@ -1,35 +1,32 @@
 """WebAuthn / passkeys as a second factor.
 
-This module wraps the (optional) `webauthn` PyPI library and falls back
-to a deterministic stub when the library isn't installed. The stub still
-persists a `WebAuthnCredential` row so the rest of the app (settings UI,
-2FA enforcement check, account export) treats the user as enrolled — it
-just can't run the full FIDO2 ceremony.
+Three layers:
 
-Two layers:
+1. **Stub** (`register_stub`, `verify_assertion_stub`) — synthetic enrol
+   that records a `WebAuthnCredential` row without doing the FIDO2
+   ceremony. Useful for tests, deployments without the `webauthn`
+   package, and as a fallback at /user/2fa when the JS hasn't run.
 
-1. `register_stub(user, label)` — record that a user has enrolled a
-   second-factor key. Generates a synthetic `credential_id` and stores
-   no real public key. Useful for tests and self-hosted deployments
-   without the `webauthn` library.
+2. **Full ceremony** (`begin_registration`, `complete_registration`,
+   `begin_authentication`, `complete_authentication`) — drives the
+   `py_webauthn` library. The challenge stays in the Flask session so
+   the response that comes back from the browser can be verified
+   against it. Public key + sign counter persist on the credential row.
 
-2. `begin_registration(user)` / `complete_registration(user, response)`
-   and `begin_authentication(user)` / `complete_authentication(user, response)`
-   are placeholders that raise `WebAuthnError` until the `webauthn`
-   package is wired. Adding it later is mechanical:
-
-       client_data, attestation = response["clientDataJSON"], response["attestationObject"]
-       webauthn.verify_registration_response(...)
-
-The caller (settings view, /user/2fa) talks to `is_supported`,
-`list_for_user`, `register_stub`, `delete`, `verify_assertion_stub`.
+3. **Helpers** (`is_supported`, `list_for_user`, `delete`,
+   `has_credential`) — boring DB lookups consumed by settings views,
+   2FA enforcement middleware, and account export.
 """
 from __future__ import annotations
 
 import base64
+import json
 import logging
 import os
 import secrets
+from typing import Any
+
+from flask import session
 
 from filenergy import db
 from filenergy.models import WebAuthnCredential, utcnow
@@ -37,15 +34,30 @@ from filenergy.models import WebAuthnCredential, utcnow
 log = logging.getLogger(__name__)
 
 
+# Session keys for the (short-lived) challenge values.
+_REG_CHALLENGE_KEY = "webauthn_reg_challenge"
+_REG_USER_HANDLE_KEY = "webauthn_reg_user_handle"
+_AUTH_CHALLENGE_KEY = "webauthn_auth_challenge"
+
+
 class WebAuthnError(RuntimeError):
     pass
+
+
+def _has_lib() -> bool:
+    try:
+        import webauthn  # noqa: F401
+        return True
+    except ImportError:
+        return False
 
 
 def is_supported() -> bool:
     """Whether the UI should expose the passkey enrolment form.
 
     Self-hosted operators can disable the experience entirely with
-    `FILENERGY_WEBAUTHN_DISABLED=true`.
+    `FILENERGY_WEBAUTHN_DISABLED=true`. The stub flow works without
+    `py_webauthn` installed; only the full ceremony requires it.
     """
     return os.environ.get("FILENERGY_WEBAUTHN_DISABLED", "").lower() != "true"
 
@@ -59,30 +71,12 @@ def list_for_user(user) -> list[WebAuthnCredential]:
     )
 
 
-def register_stub(user, *, label: str) -> WebAuthnCredential:
-    """Synthetic enrolment used by the simple "register a key" form.
-
-    Real WebAuthn registration requires JS-driven ceremony. This stub is
-    enough to:
-      * mark the user as having a second factor (so 2FA enforcement is
-        satisfied without TOTP);
-      * surface a per-key entry in the settings list with a label and a
-        delete button;
-      * track per-key usage timestamps from `verify_assertion_stub`.
-    """
-    if not is_supported():
-        raise WebAuthnError("WebAuthn is disabled on this instance.")
-    cred_id = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
-    cred = WebAuthnCredential(
-        user_id=user.id,
-        credential_id=cred_id,
-        public_key="stub",  # stub: no real key material
-        sign_count=0,
-        label=label[:120],
-    )
-    db.session.add(cred)
-    db.session.commit()
-    return cred
+def has_credential(user) -> bool:
+    if user is None or not getattr(user, "id", None):
+        return False
+    return WebAuthnCredential.query.filter_by(
+        user_id=user.id
+    ).first() is not None
 
 
 def delete(user, cred_id: int) -> bool:
@@ -96,19 +90,31 @@ def delete(user, cred_id: int) -> bool:
     return True
 
 
-def has_credential(user) -> bool:
-    if user is None or not getattr(user, "id", None):
-        return False
-    return WebAuthnCredential.query.filter_by(
-        user_id=user.id
-    ).first() is not None
+# ---------------------------------------------------------------------------
+# Stub flow — fast path used by tests and pre-JS deployments
+# ---------------------------------------------------------------------------
+
+
+def register_stub(user, *, label: str) -> WebAuthnCredential:
+    """Synthetic enrolment used by the simple "register a key" form."""
+    if not is_supported():
+        raise WebAuthnError("WebAuthn is disabled on this instance.")
+    cred_id = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
+    cred = WebAuthnCredential(
+        user_id=user.id,
+        credential_id=cred_id,
+        public_key="stub",
+        sign_count=0,
+        label=label[:120],
+    )
+    db.session.add(cred)
+    db.session.commit()
+    return cred
 
 
 def verify_assertion_stub(user, credential_id: str) -> bool:
-    """Mark `credential_id` as used. Real verification requires the full
-    WebAuthn ceremony (challenge match + signature check) which lives in
-    `complete_authentication`. The stub is enough for tests and for
-    fallback when the JS hasn't been integrated yet.
+    """Mark `credential_id` as used. Real verification is in
+    `complete_authentication` — the stub is enough for tests / fallback.
     """
     cred = WebAuthnCredential.query.filter_by(
         user_id=user.id, credential_id=credential_id
@@ -122,30 +128,182 @@ def verify_assertion_stub(user, credential_id: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Real WebAuthn ceremony — populated when `webauthn` library is installed.
+# Full FIDO2 ceremony — wraps py_webauthn.
 # ---------------------------------------------------------------------------
 
 
-def begin_registration(user, *, rp_id: str, rp_name: str) -> dict:
-    raise WebAuthnError(
-        "Full WebAuthn registration requires the `webauthn` package. "
-        "Use `register_stub` for now."
+def _rp_id() -> str:
+    """Relying-Party identifier. Browser ties credentials to this domain;
+    must match `request.host` (sans port). Operators override per-deploy.
+    """
+    return os.environ.get("FILENERGY_RP_ID", "localhost")
+
+
+def _rp_name() -> str:
+    return os.environ.get("FILENERGY_RP_NAME", "Filenergy")
+
+
+def _expected_origin() -> str:
+    """Origin the browser sends in `clientDataJSON`. Defaults to https://<rp_id>
+    for production; override with `FILENERGY_RP_ORIGIN` (e.g. for localhost
+    development, set http://localhost:5000)."""
+    explicit = os.environ.get("FILENERGY_RP_ORIGIN")
+    if explicit:
+        return explicit
+    rp = _rp_id()
+    if rp == "localhost":
+        return "http://localhost:5000"
+    return f"https://{rp}"
+
+
+def _b64url_encode(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(s: str) -> bytes:
+    pad = 4 - (len(s) % 4)
+    if pad != 4:
+        s = s + ("=" * pad)
+    return base64.urlsafe_b64decode(s)
+
+
+def begin_registration(user) -> dict[str, Any]:
+    """Start a registration ceremony. Returns the
+    PublicKeyCredentialCreationOptions dict the browser passes to
+    `navigator.credentials.create({ publicKey })`.
+
+    Raises `WebAuthnError` if `py_webauthn` is missing.
+    """
+    if not _has_lib():
+        raise WebAuthnError(
+            "py_webauthn is not installed. Use register_stub instead."
+        )
+    if not is_supported():
+        raise WebAuthnError("WebAuthn is disabled on this instance.")
+
+    import webauthn as wa
+
+    user_handle = secrets.token_bytes(32)
+    challenge = secrets.token_bytes(32)
+    options = wa.generate_registration_options(
+        rp_id=_rp_id(),
+        rp_name=_rp_name(),
+        user_id=user_handle,
+        user_name=user.email or user.username or str(user.id),
+        user_display_name=user.email or user.username or "",
+        challenge=challenge,
     )
+    session[_REG_CHALLENGE_KEY] = _b64url_encode(challenge)
+    session[_REG_USER_HANDLE_KEY] = _b64url_encode(user_handle)
+
+    return json.loads(wa.options_to_json(options))
 
 
-def complete_registration(user, response: dict) -> WebAuthnCredential:
-    raise WebAuthnError(
-        "Full WebAuthn registration requires the `webauthn` package."
+def complete_registration(
+    user, *, response: dict[str, Any], label: str = "Security key",
+) -> WebAuthnCredential:
+    """Finish a registration ceremony.
+
+    `response` is the JSON body from
+    `navigator.credentials.create(...).response`. We verify it against the
+    challenge we stashed in `begin_registration`, then persist the
+    credential id + public key + sign counter.
+    """
+    if not _has_lib():
+        raise WebAuthnError("py_webauthn is not installed.")
+    challenge_b64 = session.pop(_REG_CHALLENGE_KEY, None)
+    session.pop(_REG_USER_HANDLE_KEY, None)
+    if not challenge_b64:
+        raise WebAuthnError("No registration challenge in session.")
+
+    import webauthn as wa
+    try:
+        verified = wa.verify_registration_response(
+            credential=response,
+            expected_challenge=_b64url_decode(challenge_b64),
+            expected_rp_id=_rp_id(),
+            expected_origin=_expected_origin(),
+        )
+    except Exception as exc:
+        raise WebAuthnError(f"Registration verification failed: {exc}") from exc
+
+    cred = WebAuthnCredential(
+        user_id=user.id,
+        credential_id=_b64url_encode(verified.credential_id),
+        public_key=_b64url_encode(verified.credential_public_key),
+        sign_count=verified.sign_count,
+        label=label[:120],
     )
+    db.session.add(cred)
+    db.session.commit()
+    return cred
 
 
-def begin_authentication(user, *, rp_id: str) -> dict:
-    raise WebAuthnError(
-        "Full WebAuthn authentication requires the `webauthn` package."
+def begin_authentication(user) -> dict[str, Any]:
+    """Start an authentication ceremony for `user`. Returns the
+    PublicKeyCredentialRequestOptions dict for `navigator.credentials.get`.
+    """
+    if not _has_lib():
+        raise WebAuthnError("py_webauthn is not installed.")
+
+    import webauthn as wa
+    from webauthn.helpers.structs import PublicKeyCredentialDescriptor
+
+    creds = list_for_user(user)
+    if not creds:
+        raise WebAuthnError("User has no registered credentials.")
+
+    challenge = secrets.token_bytes(32)
+    allow_credentials = [
+        PublicKeyCredentialDescriptor(id=_b64url_decode(c.credential_id))
+        for c in creds
+    ]
+    options = wa.generate_authentication_options(
+        rp_id=_rp_id(),
+        challenge=challenge,
+        allow_credentials=allow_credentials,
     )
+    session[_AUTH_CHALLENGE_KEY] = _b64url_encode(challenge)
+    return json.loads(wa.options_to_json(options))
 
 
-def complete_authentication(user, response: dict) -> bool:
-    raise WebAuthnError(
-        "Full WebAuthn authentication requires the `webauthn` package."
-    )
+def complete_authentication(user, *, response: dict[str, Any]) -> bool:
+    """Finish an authentication ceremony.
+
+    Returns True when the assertion verifies against the stored public key
+    and the sign counter is monotonically increasing. Updates the row's
+    sign counter and `last_used_at` on success.
+    """
+    if not _has_lib():
+        raise WebAuthnError("py_webauthn is not installed.")
+    challenge_b64 = session.pop(_AUTH_CHALLENGE_KEY, None)
+    if not challenge_b64:
+        raise WebAuthnError("No authentication challenge in session.")
+
+    raw_id_b64 = response.get("id") or response.get("rawId")
+    if not raw_id_b64:
+        return False
+    cred = WebAuthnCredential.query.filter_by(
+        user_id=user.id, credential_id=raw_id_b64,
+    ).first()
+    if cred is None or cred.public_key == "stub":
+        return False
+
+    import webauthn as wa
+    try:
+        verified = wa.verify_authentication_response(
+            credential=response,
+            expected_challenge=_b64url_decode(challenge_b64),
+            expected_rp_id=_rp_id(),
+            expected_origin=_expected_origin(),
+            credential_public_key=_b64url_decode(cred.public_key),
+            credential_current_sign_count=cred.sign_count or 0,
+        )
+    except Exception as exc:
+        log.info("WebAuthn authentication failed: %s", exc)
+        return False
+
+    cred.sign_count = verified.new_sign_count
+    cred.last_used_at = utcnow()
+    db.session.commit()
+    return True

--- a/filenergy/services/webhooks.py
+++ b/filenergy/services/webhooks.py
@@ -15,7 +15,6 @@ import hmac
 import json
 import logging
 import secrets
-import threading
 from typing import Any
 from urllib import error as urllib_error
 from urllib import request as urllib_request
@@ -26,6 +25,7 @@ from filenergy.models import (
     WebhookSubscription,
     utcnow,
 )
+from filenergy.services import jobs
 
 log = logging.getLogger(__name__)
 
@@ -111,20 +111,27 @@ def dispatch(workspace_id: int, event_type: str, payload: dict[str, Any]) -> int
         return 0
 
     body = json.dumps({"event": event_type, "data": payload, "workspace_id": workspace_id})
+    # 5 attempts with 2s exponential backoff (2/4/8/16s) covers a
+    # consumer briefly under load without DOSing them. Tests pin
+    # FILENERGY_WEBHOOK_RETRIES=0 so each delivery runs exactly once.
+    import os
+    retries = int(os.environ.get("FILENERGY_WEBHOOK_RETRIES", "4"))
+    backoff = int(os.environ.get("FILENERGY_WEBHOOK_BACKOFF_S", "2"))
     for sub in interested:
-        if app.config.get("TESTING"):
-            _deliver_one(sub.id, event_type, body)
-        else:
-            threading.Thread(
-                target=_deliver_async, args=(sub.id, event_type, body),
-                name=f"webhook-{sub.id}", daemon=True,
-            ).start()
+        jobs.enqueue(
+            "filenergy.services.webhooks._deliver_one",
+            sub.id, event_type, body,
+            retries=retries,
+            retry_backoff_seconds=backoff,
+        )
     return len(interested)
 
 
-def _deliver_async(subscription_id: int, event_type: str, body: str) -> None:
-    with app.app_context():
-        _deliver_one(subscription_id, event_type, body)
+class WebhookDeliveryFailed(Exception):
+    """Raised after `_deliver_one` records a transient failure so the
+    jobs-queue retry policy can re-run the delivery. 4xx responses are
+    intentionally NOT retried (client error in the consumer's payload
+    handler — retrying just hammers them)."""
 
 
 def _deliver_one(subscription_id: int, event_type: str, body: str) -> WebhookDelivery:
@@ -150,6 +157,7 @@ def _deliver_one(subscription_id: int, event_type: str, body: str) -> WebhookDel
         "User-Agent": "Filenergy-Webhook/1",
     }
 
+    transient_failure = False
     try:
         req = urllib_request.Request(
             sub.url, data=body_bytes, headers=headers, method="POST"
@@ -162,7 +170,11 @@ def _deliver_one(subscription_id: int, event_type: str, body: str) -> WebhookDel
         delivery.delivered_at = utcnow()
         sub.last_status = status
         sub.last_attempt_at = utcnow()
-        if status >= 400:
+        if status >= 500:
+            sub.failure_count = (sub.failure_count or 0) + 1
+            delivery.error = f"HTTP {status}"
+            transient_failure = True
+        elif status >= 400:
             sub.failure_count = (sub.failure_count or 0) + 1
             delivery.error = f"HTTP {status}"
         else:
@@ -173,10 +185,14 @@ def _deliver_one(subscription_id: int, event_type: str, body: str) -> WebhookDel
         sub.last_status = exc.code
         sub.last_attempt_at = utcnow()
         sub.failure_count = (sub.failure_count or 0) + 1
+        transient_failure = exc.code >= 500
     except Exception as exc:
         delivery.error = str(exc)[:500]
         sub.last_attempt_at = utcnow()
         sub.failure_count = (sub.failure_count or 0) + 1
+        transient_failure = True
 
     db.session.commit()
+    if transient_failure:
+        raise WebhookDeliveryFailed(delivery.error or "transient failure")
     return delivery

--- a/filenergy/static/css/tailwind.src.css
+++ b/filenergy/static/css/tailwind.src.css
@@ -1,0 +1,29 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer components {
+  .btn          { @apply inline-flex items-center justify-center gap-1.5 rounded-md border border-slate-200 bg-white px-3.5 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60; }
+  .btn-primary  { @apply border-transparent bg-brand-500 text-white shadow-sm hover:bg-brand-600; }
+  .btn-danger   { @apply border-transparent bg-rose-600 text-white hover:bg-rose-700; }
+  .btn-ghost    { @apply border-transparent bg-transparent shadow-none hover:bg-slate-100; }
+  .btn-large    { @apply px-5 py-2.5 text-base; }
+  .input        { @apply block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/30; }
+  .label        { @apply block text-sm font-medium text-slate-700; }
+  .card         { @apply rounded-xl border border-slate-200 bg-white p-5 shadow-sm; }
+  .card-title   { @apply text-base font-semibold text-slate-900; }
+  .pill         { @apply inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700; }
+  .pill-brand   { @apply bg-brand-100 text-brand-700; }
+  .pill-success { @apply bg-emerald-100 text-emerald-700; }
+  .pill-warn    { @apply bg-amber-100 text-amber-700; }
+  .pill-error   { @apply bg-rose-100 text-rose-700; }
+  .table        { @apply w-full text-left text-sm; }
+  .table th     { @apply border-b border-slate-200 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500; }
+  .table td     { @apply border-b border-slate-100 px-3 py-2.5 align-middle; }
+  .nav-link     { @apply rounded-md px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-100 hover:text-slate-900; }
+  .nav-link-active { @apply bg-slate-100 text-slate-900; }
+  .flash        { @apply mb-3 rounded-md border px-4 py-2 text-sm; }
+  .flash-error  { @apply border-rose-200 bg-rose-50 text-rose-700; }
+  .flash-success{ @apply border-emerald-200 bg-emerald-50 text-emerald-700; }
+  .prose-thin p { @apply mb-2; }
+}

--- a/filenergy/templates/base.html
+++ b/filenergy/templates/base.html
@@ -8,56 +8,63 @@
     <link rel="shortcut icon" href="/static/img/logo.png"/>
 
     <script type="text/javascript" src="/static/js/jquery.min.js"></script>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script>
-      tailwind.config = {
-        theme: {
-          extend: {
-            fontFamily: {
-              sans: ["ui-sans-serif", "system-ui", "-apple-system", "Segoe UI", "Roboto", "sans-serif"],
-            },
-            colors: {
-              brand: {
-                50:  "#eff6ff",
-                100: "#dbeafe",
-                500: "#2563eb",
-                600: "#1d4ed8",
-                700: "#1e40af",
+
+    {# Use the compiled, minified Tailwind output when it has been built
+       (production / Docker image). Fall back to the Play CDN + inline
+       config so `flask run` works zero-config in dev. The CDN version
+       has `'unsafe-eval'` in CSP because it JIT-compiles in the browser. #}
+    {% if css_bundle_built %}
+      <link rel="stylesheet" href="/static/css/app.css">
+    {% else %}
+      <script src="https://cdn.tailwindcss.com"></script>
+      <script>
+        tailwind.config = {
+          theme: {
+            extend: {
+              fontFamily: {
+                sans: ["ui-sans-serif", "system-ui", "-apple-system", "Segoe UI", "Roboto", "sans-serif"],
+              },
+              colors: {
+                brand: {
+                  50:  "#eff6ff",
+                  100: "#dbeafe",
+                  500: "#2563eb",
+                  600: "#1d4ed8",
+                  700: "#1e40af",
+                },
               },
             },
           },
-        },
-      };
-    </script>
-
-    <!-- Component classes used across templates. Tailwind CDN compiles them on the fly. -->
-    <style type="text/tailwindcss">
-      @layer components {
-        .btn          { @apply inline-flex items-center justify-center gap-1.5 rounded-md border border-slate-200 bg-white px-3.5 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60; }
-        .btn-primary  { @apply border-transparent bg-brand-500 text-white shadow-sm hover:bg-brand-600; }
-        .btn-danger   { @apply border-transparent bg-rose-600 text-white hover:bg-rose-700; }
-        .btn-ghost    { @apply border-transparent bg-transparent shadow-none hover:bg-slate-100; }
-        .btn-large    { @apply px-5 py-2.5 text-base; }
-        .input        { @apply block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/30; }
-        .label        { @apply block text-sm font-medium text-slate-700; }
-        .card         { @apply rounded-xl border border-slate-200 bg-white p-5 shadow-sm; }
-        .card-title   { @apply text-base font-semibold text-slate-900; }
-        .pill         { @apply inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700; }
-        .pill-brand   { @apply bg-brand-100 text-brand-700; }
-        .pill-success { @apply bg-emerald-100 text-emerald-700; }
-        .pill-warn    { @apply bg-amber-100 text-amber-700; }
-        .pill-error   { @apply bg-rose-100 text-rose-700; }
-        .table        { @apply w-full text-left text-sm; }
-        .table th     { @apply border-b border-slate-200 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500; }
-        .table td     { @apply border-b border-slate-100 px-3 py-2.5 align-middle; }
-        .nav-link     { @apply rounded-md px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-100 hover:text-slate-900; }
-        .nav-link-active { @apply bg-slate-100 text-slate-900; }
-        .flash        { @apply mb-3 rounded-md border px-4 py-2 text-sm; }
-        .flash-error  { @apply border-rose-200 bg-rose-50 text-rose-700; }
-        .flash-success{ @apply border-emerald-200 bg-emerald-50 text-emerald-700; }
-        .prose-thin p { @apply mb-2; }
-      }
-    </style>
+        };
+      </script>
+      <style type="text/tailwindcss">
+        @layer components {
+          .btn          { @apply inline-flex items-center justify-center gap-1.5 rounded-md border border-slate-200 bg-white px-3.5 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60; }
+          .btn-primary  { @apply border-transparent bg-brand-500 text-white shadow-sm hover:bg-brand-600; }
+          .btn-danger   { @apply border-transparent bg-rose-600 text-white hover:bg-rose-700; }
+          .btn-ghost    { @apply border-transparent bg-transparent shadow-none hover:bg-slate-100; }
+          .btn-large    { @apply px-5 py-2.5 text-base; }
+          .input        { @apply block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/30; }
+          .label        { @apply block text-sm font-medium text-slate-700; }
+          .card         { @apply rounded-xl border border-slate-200 bg-white p-5 shadow-sm; }
+          .card-title   { @apply text-base font-semibold text-slate-900; }
+          .pill         { @apply inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700; }
+          .pill-brand   { @apply bg-brand-100 text-brand-700; }
+          .pill-success { @apply bg-emerald-100 text-emerald-700; }
+          .pill-warn    { @apply bg-amber-100 text-amber-700; }
+          .pill-error   { @apply bg-rose-100 text-rose-700; }
+          .table        { @apply w-full text-left text-sm; }
+          .table th     { @apply border-b border-slate-200 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500; }
+          .table td     { @apply border-b border-slate-100 px-3 py-2.5 align-middle; }
+          .nav-link     { @apply rounded-md px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-100 hover:text-slate-900; }
+          .nav-link-active { @apply bg-slate-100 text-slate-900; }
+          .flash        { @apply mb-3 rounded-md border px-4 py-2 text-sm; }
+          .flash-error  { @apply border-rose-200 bg-rose-50 text-rose-700; }
+          .flash-success{ @apply border-emerald-200 bg-emerald-50 text-emerald-700; }
+          .prose-thin p { @apply mb-2; }
+        }
+      </style>
+    {% endif %}
 
     <script type="text/javascript">
       $(function() {

--- a/filenergy/templates/settings/security.html
+++ b/filenergy/templates/settings/security.html
@@ -59,15 +59,96 @@
   {% else %}
     <p class="mt-3 text-xs text-slate-500">No passkeys registered yet.</p>
   {% endif %}
-  <form class="mt-3 flex gap-2"
+  <form class="mt-3 flex gap-2" id="webauthn-form"
         method="POST"
         action="{{ url_for('settings.webauthn_register') }}">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-    <input class="input flex-1" type="text" name="label"
+    <input class="input flex-1" id="webauthn-label" type="text" name="label"
            placeholder="Key name (e.g. YubiKey 5)" required>
     <button class="btn btn-primary" type="submit">Register</button>
   </form>
+  <p id="webauthn-status" class="mt-2 hidden text-xs text-slate-500"></p>
 </section>
+
+<script>
+// Progressive enhancement: if the browser exposes navigator.credentials.create,
+// run the real FIDO2 ceremony. Otherwise we fall back to the form POST that
+// records a stub credential — works in tests, headless deploys, and old browsers.
+(function() {
+  if (!window.PublicKeyCredential || !navigator.credentials || !navigator.credentials.create) {
+    return; // graceful fallback to stub form
+  }
+  function b64urlToBuf(s) {
+    s = s.replace(/-/g, '+').replace(/_/g, '/');
+    while (s.length % 4) s += '=';
+    var raw = atob(s);
+    var arr = new Uint8Array(raw.length);
+    for (var i = 0; i < raw.length; i++) arr[i] = raw.charCodeAt(i);
+    return arr.buffer;
+  }
+  function bufToB64url(b) {
+    var bytes = new Uint8Array(b);
+    var s = '';
+    for (var i = 0; i < bytes.byteLength; i++) s += String.fromCharCode(bytes[i]);
+    return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  }
+  function show(msg, ok) {
+    var $s = $('#webauthn-status');
+    $s.removeClass('hidden text-rose-600 text-emerald-700');
+    $s.addClass(ok === false ? 'text-rose-600' : 'text-emerald-700');
+    $s.text(msg);
+  }
+  $('#webauthn-form').on('submit', async function(e) {
+    e.preventDefault();
+    var label = $('#webauthn-label').val();
+    show('Awaiting your security key...');
+    try {
+      var beginResp = await fetch('{{ url_for("settings.webauthn_begin") }}', {
+        method: 'POST',
+        headers: {'X-CSRFToken': $('meta[name=csrf-token]').attr('content')},
+      });
+      if (!beginResp.ok) throw new Error('begin failed');
+      var options = await beginResp.json();
+      options.challenge = b64urlToBuf(options.challenge);
+      options.user.id = b64urlToBuf(options.user.id);
+      if (options.excludeCredentials) {
+        options.excludeCredentials = options.excludeCredentials.map(function(c) {
+          return Object.assign({}, c, {id: b64urlToBuf(c.id)});
+        });
+      }
+      var cred = await navigator.credentials.create({publicKey: options});
+      var payload = {
+        label: label,
+        response: {
+          id: cred.id,
+          rawId: bufToB64url(cred.rawId),
+          type: cred.type,
+          response: {
+            clientDataJSON: bufToB64url(cred.response.clientDataJSON),
+            attestationObject: bufToB64url(cred.response.attestationObject),
+          },
+        },
+      };
+      var done = await fetch('{{ url_for("settings.webauthn_complete") }}', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': $('meta[name=csrf-token]').attr('content'),
+        },
+        body: JSON.stringify(payload),
+      });
+      if (!done.ok) {
+        var err = await done.json().catch(function(){ return {error: 'failed'}; });
+        throw new Error(err.error || 'failed');
+      }
+      show('Passkey registered. Reloading…');
+      setTimeout(function() { location.reload(); }, 600);
+    } catch (err) {
+      show('Could not register: ' + (err.message || err), false);
+    }
+  });
+})();
+</script>
 {% endif %}
 
 <section class="card">

--- a/filenergy/templates/user/two_factor.html
+++ b/filenergy/templates/user/two_factor.html
@@ -21,6 +21,94 @@
 
       <button type="submit" class="btn btn-primary w-full">Verify</button>
     </form>
+
+    {% if webauthn_enabled %}
+      <div class="my-4 flex items-center gap-3 text-xs uppercase tracking-wide text-slate-400">
+        <span class="h-px flex-1 bg-slate-200"></span>or<span class="h-px flex-1 bg-slate-200"></span>
+      </div>
+      <button id="webauthn-btn" class="btn w-full" type="button">
+        Use security key / passkey
+      </button>
+      <p id="webauthn-status" class="mt-2 hidden text-center text-xs text-slate-500"></p>
+    {% endif %}
   </div>
 </div>
+
+{% if webauthn_enabled %}
+<script>
+(function() {
+  if (!window.PublicKeyCredential || !navigator.credentials || !navigator.credentials.get) {
+    $('#webauthn-btn').prop('disabled', true).text('Browser does not support passkeys');
+    return;
+  }
+  function b64urlToBuf(s) {
+    s = s.replace(/-/g, '+').replace(/_/g, '/');
+    while (s.length % 4) s += '=';
+    var raw = atob(s);
+    var arr = new Uint8Array(raw.length);
+    for (var i = 0; i < raw.length; i++) arr[i] = raw.charCodeAt(i);
+    return arr.buffer;
+  }
+  function bufToB64url(b) {
+    var bytes = new Uint8Array(b);
+    var s = '';
+    for (var i = 0; i < bytes.byteLength; i++) s += String.fromCharCode(bytes[i]);
+    return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  }
+  function show(msg, ok) {
+    var $s = $('#webauthn-status');
+    $s.removeClass('hidden text-rose-600 text-emerald-700');
+    $s.addClass(ok === false ? 'text-rose-600' : 'text-slate-500');
+    $s.text(msg);
+  }
+  $('#webauthn-btn').on('click', async function() {
+    show('Awaiting your security key...');
+    try {
+      var beginResp = await fetch('{{ url_for("user.two_factor_webauthn_begin") }}', {
+        method: 'POST',
+        headers: {'X-CSRFToken': $('meta[name=csrf-token]').attr('content')},
+      });
+      if (!beginResp.ok) throw new Error('begin failed');
+      var options = await beginResp.json();
+      options.challenge = b64urlToBuf(options.challenge);
+      if (options.allowCredentials) {
+        options.allowCredentials = options.allowCredentials.map(function(c) {
+          return Object.assign({}, c, {id: b64urlToBuf(c.id)});
+        });
+      }
+      var assertion = await navigator.credentials.get({publicKey: options});
+      var payload = {
+        response: {
+          id: assertion.id,
+          rawId: bufToB64url(assertion.rawId),
+          type: assertion.type,
+          response: {
+            clientDataJSON: bufToB64url(assertion.response.clientDataJSON),
+            authenticatorData: bufToB64url(assertion.response.authenticatorData),
+            signature: bufToB64url(assertion.response.signature),
+            userHandle: assertion.response.userHandle ? bufToB64url(assertion.response.userHandle) : null,
+          },
+        },
+      };
+      var done = await fetch('{{ url_for("user.two_factor_webauthn_complete") }}', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': $('meta[name=csrf-token]').attr('content'),
+        },
+        body: JSON.stringify(payload),
+      });
+      if (!done.ok) {
+        var err = await done.json().catch(function(){ return {error: 'failed'}; });
+        throw new Error(err.error || 'failed');
+      }
+      var result = await done.json();
+      location.href = result.next || '/';
+    } catch (err) {
+      show('Sign-in failed: ' + (err.message || err), false);
+    }
+  });
+})();
+</script>
+{% endif %}
 {% endblock %}

--- a/filenergy/views/settings_views.py
+++ b/filenergy/views/settings_views.py
@@ -140,6 +140,39 @@ def webauthn_register():
     return redirect(url_for("settings.security"))
 
 
+@settings_bp.route("/security/webauthn/begin", methods=["POST"])
+@login_required
+def webauthn_begin():
+    """Start a real FIDO2 registration ceremony — returns the
+    PublicKeyCredentialCreationOptions dict for `navigator.credentials.create`."""
+    from flask import jsonify
+    try:
+        options = webauthn.begin_registration(g.user)
+    except webauthn.WebAuthnError as exc:
+        return jsonify({"error": str(exc)}), 400
+    return jsonify(options)
+
+
+@settings_bp.route("/security/webauthn/complete", methods=["POST"])
+@login_required
+def webauthn_complete():
+    """Finish a real FIDO2 registration ceremony."""
+    from flask import jsonify
+    payload = request.get_json(silent=True) or {}
+    label = (payload.get("label") or "Security key").strip()[:120]
+    response = payload.get("response") or {}
+    try:
+        cred = webauthn.complete_registration(
+            g.user, response=response, label=label,
+        )
+    except webauthn.WebAuthnError as exc:
+        return jsonify({"error": str(exc)}), 400
+    events.log_event(
+        events.WEBAUTHN_REGISTERED, user=g.user, credential_id=cred.id,
+    )
+    return jsonify({"id": cred.id, "label": cred.label})
+
+
 @settings_bp.route("/security/webauthn/<int:cred_id>/delete", methods=["POST"])
 @login_required
 def webauthn_delete(cred_id):

--- a/filenergy/views/user.py
+++ b/filenergy/views/user.py
@@ -72,7 +72,58 @@ def login_post():
 def two_factor():
     if not session.get(PENDING_2FA_KEY):
         return redirect(url_for("user.login"))
-    return render_template("user/two_factor.html")
+    user_id = session.get(PENDING_2FA_KEY)
+    user = User.query.get(user_id) if user_id else None
+    has_passkey = bool(user and webauthn.has_credential(user))
+    return render_template(
+        "user/two_factor.html",
+        webauthn_enabled=has_passkey,
+    )
+
+
+@user_bp.route("/2fa/webauthn/begin", methods=["POST"])
+def two_factor_webauthn_begin():
+    from flask import jsonify
+    user_id = session.get(PENDING_2FA_KEY)
+    if not user_id:
+        return jsonify({"error": "no pending login"}), 400
+    user = User.query.get(user_id)
+    if user is None:
+        return jsonify({"error": "no pending login"}), 400
+    try:
+        options = webauthn.begin_authentication(user)
+    except webauthn.WebAuthnError as exc:
+        return jsonify({"error": str(exc)}), 400
+    return jsonify(options)
+
+
+@user_bp.route("/2fa/webauthn/complete", methods=["POST"])
+def two_factor_webauthn_complete():
+    from flask import jsonify
+    user_id = session.get(PENDING_2FA_KEY)
+    if not user_id:
+        return jsonify({"error": "no pending login"}), 400
+    user = User.query.get(user_id)
+    if user is None:
+        return jsonify({"error": "no pending login"}), 400
+    payload = request.get_json(silent=True) or {}
+    response = payload.get("response") or {}
+    try:
+        ok = webauthn.complete_authentication(user, response=response)
+    except webauthn.WebAuthnError as exc:
+        return jsonify({"error": str(exc)}), 400
+    if not ok:
+        return jsonify({"error": "verification failed"}), 400
+
+    next_ = session.pop(PENDING_2FA_NEXT, None) or url_for("index.index")
+    session.pop(PENDING_2FA_KEY, None)
+    login_user(user)
+    from filenergy.services import workspaces
+    workspaces.ensure_default_for(user)
+    session_service.issue(user)
+    events.log_event(events.USER_LOGGED_IN, user=user, via="webauthn")
+    events.log_event(events.WEBAUTHN_VERIFIED, user=user)
+    return jsonify({"ok": True, "next": next_})
 
 
 @user_bp.route("/2fa", methods=["POST"])

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "filenergy-ui",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build:css": "tailwindcss -i ./filenergy/static/css/tailwind.src.css -o ./filenergy/static/css/app.css --minify",
+    "watch:css": "tailwindcss -i ./filenergy/static/css/tailwind.src.css -o ./filenergy/static/css/app.css --watch"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.4.0"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,9 @@ qrcode>=7.4
 authlib>=1.3
 Flask-Migrate>=4.0
 fpdf2>=2.7
+# WebAuthn / passkey ceremony — UI gracefully falls back to the stub flow
+# when this isn't installed.
+webauthn>=2.5
 # Optional: install + run an `rq` worker to use FILENERGY_JOBS_BACKEND=rq
 # rq>=1.16
 # redis>=5.0

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,23 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./filenergy/templates/**/*.html",
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ["ui-sans-serif", "system-ui", "-apple-system", "Segoe UI", "Roboto", "sans-serif"],
+      },
+      colors: {
+        brand: {
+          50:  "#eff6ff",
+          100: "#dbeafe",
+          500: "#2563eb",
+          600: "#1d4ed8",
+          700: "#1e40af",
+        },
+      },
+    },
+  },
+  plugins: [],
+};

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,9 @@ os.environ["FILENERGY_DB_PATH"] = str(_TMP / "test.db")
 os.environ["FILENERGY_DB_URI"] = f"sqlite:///{_TMP / 'test.db'}"
 os.environ["FILENERGY_UPLOAD_DIR"] = str(_TMP / "files")
 os.environ["FILENERGY_SECRET_KEY"] = "test-secret-key"
+# Tests run jobs synchronously; default retries=0 so webhook tests still
+# observe a single delivery attempt. Specific retry tests bump this.
+os.environ.setdefault("FILENERGY_WEBHOOK_RETRIES", "0")
 
 import pytest  # noqa: E402
 

--- a/tests/test_services_jobs.py
+++ b/tests/test_services_jobs.py
@@ -155,5 +155,36 @@ def test_run_swallows_exceptions(app, caplog):
     sys.modules["__main__boom"] = types.ModuleType("__main__boom")
     sys.modules["__main__boom"].boom = boom
     with caplog.at_level("ERROR", logger="filenergy.services.jobs"):
-        jobs._run("__main__boom.boom", (), {})
+        jobs._run("__main__boom.boom", (), {}, 0, 0)
     assert any("Job" in r.message for r in caplog.records)
+
+
+def test_retries_run_until_success(app, monkeypatch):
+    """retries=N runs at most N+1 times; logs all but the final attempt."""
+    import sys, types
+    attempts = []
+
+    def flap():
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise RuntimeError("transient")
+
+    sys.modules["__main__flap"] = types.ModuleType("__main__flap")
+    sys.modules["__main__flap"].flap = flap
+    jobs.enqueue("__main__flap.flap", retries=4, retry_backoff_seconds=0)
+    assert len(attempts) == 3
+
+
+def test_retries_give_up_after_exhaustion(app):
+    """retries=2 → at most 3 attempts; persistent failures don't loop forever."""
+    import sys, types
+    attempts = []
+
+    def boom():
+        attempts.append(1)
+        raise RuntimeError("persistent")
+
+    sys.modules["__main__persistent"] = types.ModuleType("__main__persistent")
+    sys.modules["__main__persistent"].boom = boom
+    jobs.enqueue("__main__persistent.boom", retries=2, retry_backoff_seconds=0)
+    assert len(attempts) == 3

--- a/tests/test_tier3_features.py
+++ b/tests/test_tier3_features.py
@@ -405,17 +405,65 @@ def test_digest_skips_user_with_no_workspace(monkeypatch, db, app):
     assert n == 0
 
 
-def test_webauthn_full_ceremony_methods_raise_until_library_wired(db, user):
+def test_webauthn_begin_registration_returns_options(client, db, user):
+    """The full FIDO2 ceremony emits PublicKeyCredentialCreationOptions
+    that the browser feeds to navigator.credentials.create()."""
+    from filenergy.services import webauthn
+
+    # begin_* uses Flask session, so wrap in a request context.
+    with client.session_transaction():
+        pass
+    client.post(
+        "/user/login/",
+        data={"email": user.email, "password": "password"},
+    )
+    r = client.post("/settings/security/webauthn/begin")
+    assert r.status_code == 200
+    options = r.get_json()
+    # Required by the WebAuthn spec.
+    assert "challenge" in options
+    assert "rp" in options
+    assert "user" in options
+    assert "pubKeyCredParams" in options
+
+
+def test_webauthn_begin_authentication_requires_credential(db, user):
+    """No credentials registered → can't begin auth."""
     from filenergy.services import webauthn
 
     with pytest.raises(webauthn.WebAuthnError):
-        webauthn.begin_registration(user, rp_id="x", rp_name="y")
-    with pytest.raises(webauthn.WebAuthnError):
-        webauthn.complete_registration(user, {})
-    with pytest.raises(webauthn.WebAuthnError):
-        webauthn.begin_authentication(user, rp_id="x")
-    with pytest.raises(webauthn.WebAuthnError):
-        webauthn.complete_authentication(user, {})
+        webauthn.begin_authentication(user)
+
+
+def test_webauthn_complete_authentication_rejects_unknown_credential(
+    monkeypatch, app, db, user,
+):
+    """A response carrying an id we don't have on file is rejected."""
+    from flask import session
+    from filenergy.services import webauthn
+
+    with app.test_request_context():
+        session[webauthn._AUTH_CHALLENGE_KEY] = "abc"
+        ok = webauthn.complete_authentication(
+            user, response={"id": "unknown-id"}
+        )
+        assert ok is False
+
+
+def test_webauthn_complete_authentication_rejects_stub_credential(
+    monkeypatch, app, db, user,
+):
+    """Stub credentials (public_key='stub') can't pass real verification."""
+    from flask import session
+    from filenergy.services import webauthn
+
+    cred = webauthn.register_stub(user, label="stub")
+    with app.test_request_context():
+        session[webauthn._AUTH_CHALLENGE_KEY] = "abc"
+        ok = webauthn.complete_authentication(
+            user, response={"id": cred.credential_id}
+        )
+        assert ok is False
 
 
 def test_webauthn_delete_unknown_returns_false(db, user):

--- a/tests/test_tier4_features.py
+++ b/tests/test_tier4_features.py
@@ -1,0 +1,502 @@
+"""Tier-4 feature tests:
+
+- Real WebAuthn ceremony plumbing (begin/complete via py_webauthn).
+- Job queue retries (sync + thread + RQ paths).
+- Webhook delivery retries on 5xx / network errors.
+- Digest async fan-out via jobs.enqueue.
+- Tailwind compiled-bundle switch.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ---------- WebAuthn full ceremony ---------------------------------------
+
+
+def test_webauthn_begin_registration_persists_challenge_in_session(client, user):
+    """begin_registration stashes challenge + user_handle so the
+    follow-up complete_registration can verify against them."""
+    from filenergy.services import webauthn
+
+    client.post(
+        "/user/login/",
+        data={"email": user.email, "password": "password"},
+    )
+    with client.session_transaction() as s:
+        # No challenge before begin.
+        assert webauthn._REG_CHALLENGE_KEY not in s
+    r = client.post("/settings/security/webauthn/begin")
+    assert r.status_code == 200
+    with client.session_transaction() as s:
+        assert webauthn._REG_CHALLENGE_KEY in s
+
+
+def test_webauthn_begin_authentication_lists_credentials(app, db, user):
+    from filenergy.services import webauthn
+
+    cred = webauthn.register_stub(user, label="Key")
+    with app.test_request_context():
+        options = webauthn.begin_authentication(user)
+        assert options["challenge"]
+        assert options["allowCredentials"]
+        # The stub credential id appears in allowCredentials.
+        ids = [c["id"] for c in options["allowCredentials"]]
+        assert cred.credential_id in ids
+
+
+def test_webauthn_complete_registration_rejects_without_challenge(app, user):
+    """Without a challenge stashed in session, completion can't proceed."""
+    from filenergy.services import webauthn
+
+    with app.test_request_context():
+        with pytest.raises(webauthn.WebAuthnError):
+            webauthn.complete_registration(user, response={})
+
+
+def test_webauthn_endpoints_require_login(client):
+    r = client.post("/settings/security/webauthn/begin")
+    # Flask-Login redirects unauthenticated requests to /user/login/.
+    assert r.status_code in (302, 401)
+
+
+def test_two_factor_webauthn_endpoints_need_pending_login(client):
+    r = client.post("/user/2fa/webauthn/begin")
+    assert r.status_code == 400
+    r = client.post("/user/2fa/webauthn/complete", json={})
+    assert r.status_code == 400
+
+
+def test_two_factor_webauthn_complete_rejects_when_assertion_fails(
+    monkeypatch, client, db, user,
+):
+    """Bad assertion → 400, no login."""
+    from filenergy.services import webauthn
+
+    webauthn.register_stub(user, label="Key")
+    client.post(
+        "/user/login/",
+        data={"email": user.email, "password": "password"},
+    )
+    monkeypatch.setattr(
+        "filenergy.services.webauthn.complete_authentication",
+        lambda user, *, response: False,
+    )
+    r = client.post("/user/2fa/webauthn/complete", json={"response": {}})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "verification failed"
+
+
+def test_two_factor_webauthn_complete_logs_in_on_success(
+    monkeypatch, client, db, user,
+):
+    """Successful assertion finalises the login."""
+    from filenergy.services import webauthn
+
+    webauthn.register_stub(user, label="Key")
+    client.post(
+        "/user/login/",
+        data={"email": user.email, "password": "password"},
+    )
+    monkeypatch.setattr(
+        "filenergy.services.webauthn.complete_authentication",
+        lambda user, *, response: True,
+    )
+    r = client.post("/user/2fa/webauthn/complete", json={"response": {}})
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["ok"] is True
+    assert body["next"]
+    # Pending 2FA cleared.
+    with client.session_transaction() as s:
+        from filenergy.views.user import PENDING_2FA_KEY
+        assert PENDING_2FA_KEY not in s
+
+
+def test_two_factor_webauthn_complete_handles_library_error(
+    monkeypatch, client, db, user,
+):
+    """If py_webauthn raises, return 400 with the message."""
+    from filenergy.services import webauthn
+
+    webauthn.register_stub(user, label="Key")
+    client.post(
+        "/user/login/",
+        data={"email": user.email, "password": "password"},
+    )
+
+    def boom(*a, **k):
+        raise webauthn.WebAuthnError("library says no")
+
+    monkeypatch.setattr(
+        "filenergy.services.webauthn.complete_authentication", boom
+    )
+    r = client.post("/user/2fa/webauthn/complete", json={"response": {}})
+    assert r.status_code == 400
+    assert "library says no" in r.get_json()["error"]
+
+
+def test_two_factor_webauthn_begin_propagates_library_error(
+    monkeypatch, client, db, user,
+):
+    """If begin_authentication raises, /2fa/webauthn/begin returns 400."""
+    from filenergy.services import webauthn
+    from filenergy.views.user import PENDING_2FA_KEY
+
+    # Force the user into the pending-2FA state.
+    webauthn.register_stub(user, label="Key")
+    client.post(
+        "/user/login/",
+        data={"email": user.email, "password": "password"},
+    )
+    with client.session_transaction() as s:
+        assert PENDING_2FA_KEY in s
+
+    def boom(_user):
+        raise webauthn.WebAuthnError("nope")
+    monkeypatch.setattr(
+        "filenergy.services.webauthn.begin_authentication", boom,
+    )
+    r = client.post("/user/2fa/webauthn/begin")
+    assert r.status_code == 400
+    assert "nope" in r.get_json()["error"]
+
+
+def test_settings_webauthn_complete_success(monkeypatch, client, db, user):
+    """The settings complete endpoint records the credential and returns id."""
+    from filenergy.models import WebAuthnCredential
+    from filenergy.services import webauthn
+
+    client.post(
+        "/user/login/",
+        data={"email": user.email, "password": "password"},
+    )
+
+    def fake_complete(user, *, response, label):
+        cred = WebAuthnCredential(
+            user_id=user.id,
+            credential_id="fake-id",
+            public_key="fake-pk",
+            sign_count=0,
+            label=label,
+        )
+        from filenergy import db as _db
+        _db.session.add(cred)
+        _db.session.commit()
+        return cred
+
+    monkeypatch.setattr(
+        "filenergy.services.webauthn.complete_registration", fake_complete
+    )
+    r = client.post(
+        "/settings/security/webauthn/complete",
+        json={"label": "MyKey", "response": {}},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["label"] == "MyKey"
+    assert body["id"]
+
+
+def test_settings_webauthn_complete_returns_400_on_error(
+    monkeypatch, client, user,
+):
+    """Library errors surface as 400 with the message."""
+    from filenergy.services import webauthn
+
+    client.post(
+        "/user/login/",
+        data={"email": user.email, "password": "password"},
+    )
+
+    def boom(*a, **k):
+        raise webauthn.WebAuthnError("bad challenge")
+    monkeypatch.setattr(
+        "filenergy.services.webauthn.complete_registration", boom
+    )
+    r = client.post(
+        "/settings/security/webauthn/complete",
+        json={"response": {}},
+    )
+    assert r.status_code == 400
+    assert "bad challenge" in r.get_json()["error"]
+
+
+def test_settings_webauthn_begin_returns_400_on_error(monkeypatch, client, user):
+    from filenergy.services import webauthn
+
+    client.post(
+        "/user/login/",
+        data={"email": user.email, "password": "password"},
+    )
+
+    def boom(_user):
+        raise webauthn.WebAuthnError("disabled")
+    monkeypatch.setattr(
+        "filenergy.services.webauthn.begin_registration", boom
+    )
+    r = client.post("/settings/security/webauthn/begin")
+    assert r.status_code == 400
+    assert "disabled" in r.get_json()["error"]
+
+
+def test_two_factor_webauthn_begin_after_password(client, db, user):
+    """Once the password step is past, begin emits FIDO2 options."""
+    from filenergy.services import webauthn
+
+    webauthn.register_stub(user, label="Key")
+    client.post(
+        "/user/login/",
+        data={"email": user.email, "password": "password"},
+    )
+    r = client.post("/user/2fa/webauthn/begin")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert "challenge" in body
+    assert "allowCredentials" in body
+
+
+# ---------- Job queue retries -------------------------------------------
+
+
+def test_thread_backend_retries_on_transient_failure(app, monkeypatch):
+    """Thread mode also honours retries=N (sleeps suppressed under TESTING)."""
+    import sys, types
+    from filenergy.services import jobs
+
+    app.config["TESTING"] = False
+    attempts = []
+
+    def flap():
+        attempts.append(1)
+        if len(attempts) < 2:
+            raise RuntimeError("transient")
+
+    sys.modules["__main__flap2"] = types.ModuleType("__main__flap2")
+    sys.modules["__main__flap2"].flap = flap
+
+    class _SyncThread:
+        def __init__(self, target, args=(), name=None, daemon=None):
+            self.target, self.args = target, args
+
+        def start(self):
+            self.target(*self.args)
+
+    monkeypatch.setattr("threading.Thread", _SyncThread)
+    monkeypatch.delenv("FILENERGY_SYNC_JOBS", raising=False)
+    monkeypatch.delenv("FILENERGY_JOBS_BACKEND", raising=False)
+    try:
+        # Re-enable TESTING-via-config sleep skip.
+        app.config["TESTING"] = True
+        jobs.enqueue("__main__flap2.flap", retries=3, retry_backoff_seconds=0)
+    finally:
+        app.config["TESTING"] = True
+    assert len(attempts) == 2
+
+
+def test_rq_backend_uses_retry_policy_when_available(app, monkeypatch):
+    """If `rq.Retry` is importable, retries land in queue.enqueue(retry=...)."""
+    import sys, types
+    from filenergy.services import jobs
+
+    app.config["TESTING"] = False
+    monkeypatch.setenv("FILENERGY_JOBS_BACKEND", "rq")
+    monkeypatch.setenv("REDIS_URL", "redis://x")
+    monkeypatch.delenv("FILENERGY_SYNC_JOBS", raising=False)
+
+    fake_redis = types.ModuleType("redis")
+
+    class _Conn:
+        @staticmethod
+        def from_url(url):
+            return object()
+
+    fake_redis.Redis = _Conn
+
+    fake_rq = types.ModuleType("rq")
+    captured: list = []
+
+    class _Queue:
+        def __init__(self, name, connection):
+            pass
+
+        def enqueue(self, fn, *args, **kwargs):
+            captured.append(("enqueue", args, kwargs))
+
+    class _Retry:
+        def __init__(self, max, interval):
+            self.max, self.interval = max, interval
+
+    fake_rq.Queue = _Queue
+    fake_rq.Retry = _Retry
+    monkeypatch.setitem(sys.modules, "redis", fake_redis)
+    monkeypatch.setitem(sys.modules, "rq", fake_rq)
+
+    try:
+        jobs.enqueue(
+            "tests.test_tier4_features.test_rq_backend_uses_retry_policy_when_available",
+            retries=3, retry_backoff_seconds=2,
+        )
+    finally:
+        app.config["TESTING"] = True
+
+    assert captured
+    _, _, kwargs = captured[0]
+    retry = kwargs.get("retry")
+    assert retry is not None
+    assert retry.max == 3
+    # Exponential schedule.
+    assert retry.interval == [2, 4, 8]
+
+
+# ---------- Webhook retries ---------------------------------------------
+
+
+def test_webhook_5xx_response_retries(app, db, workspace, monkeypatch):
+    """Setting FILENERGY_WEBHOOK_RETRIES > 0 re-fires deliveries on 5xx."""
+    from filenergy.models import WebhookDelivery
+    from filenergy.services import webhooks
+
+    monkeypatch.setenv("FILENERGY_WEBHOOK_RETRIES", "3")
+    monkeypatch.setenv("FILENERGY_WEBHOOK_BACKOFF_S", "0")
+
+    class _FakeResponse:
+        status = 500
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self, n=None): return b"down"
+
+    monkeypatch.setattr("urllib.request.urlopen",
+                        lambda req, timeout=None: _FakeResponse())
+
+    with app.test_request_context():
+        webhooks.create(workspace, "https://x/", ["file.uploaded"])
+        webhooks.dispatch(workspace.id, "file.uploaded", {})
+
+    deliveries = WebhookDelivery.query.all()
+    # 1 initial + 3 retries.
+    assert len(deliveries) == 4
+
+
+def test_webhook_4xx_response_does_not_retry(app, db, workspace, monkeypatch):
+    """4xx is a client-side bug in the consumer's handler — retrying just
+    hammers them. Only 5xx + network errors cause retry."""
+    from filenergy.models import WebhookDelivery
+    from filenergy.services import webhooks
+
+    monkeypatch.setenv("FILENERGY_WEBHOOK_RETRIES", "3")
+    monkeypatch.setenv("FILENERGY_WEBHOOK_BACKOFF_S", "0")
+
+    class _FakeResponse:
+        status = 422
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self, n=None): return b"bad payload"
+
+    monkeypatch.setattr("urllib.request.urlopen",
+                        lambda req, timeout=None: _FakeResponse())
+
+    with app.test_request_context():
+        webhooks.create(workspace, "https://x/", ["file.uploaded"])
+        webhooks.dispatch(workspace.id, "file.uploaded", {})
+
+    deliveries = WebhookDelivery.query.all()
+    assert len(deliveries) == 1
+
+
+def test_webhook_network_error_retries(app, db, workspace, monkeypatch):
+    """Network errors are transient by definition."""
+    from filenergy.models import WebhookDelivery
+    from filenergy.services import webhooks
+
+    monkeypatch.setenv("FILENERGY_WEBHOOK_RETRIES", "2")
+    monkeypatch.setenv("FILENERGY_WEBHOOK_BACKOFF_S", "0")
+
+    def boom(req, timeout=None):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+    with app.test_request_context():
+        webhooks.create(workspace, "https://x/", ["file.uploaded"])
+        webhooks.dispatch(workspace.id, "file.uploaded", {})
+
+    deliveries = WebhookDelivery.query.all()
+    assert len(deliveries) == 3  # 1 + 2 retries
+
+
+# ---------- Digest async fan-out ----------------------------------------
+
+
+def test_send_pending_async_enqueues_per_user(
+    monkeypatch, db, user, workspace, uploaded_file,
+):
+    """async_dispatch=True hands each eligible user to the jobs queue."""
+    from filenergy.services import digest, email as email_service
+
+    monkeypatch.setattr(email_service, "send", lambda to, subject, body: True)
+    n = digest.send_pending(async_dispatch=True)
+    assert n == 1
+    db.session.refresh(user)
+    # send_for_user updates last_digest_sent_at on success.
+    assert user.last_digest_sent_at is not None
+
+
+def test_send_for_user_skips_when_already_sent_recently(
+    monkeypatch, db, user, workspace, uploaded_file,
+):
+    from filenergy.models import utcnow
+    from filenergy.services import digest, email as email_service
+
+    user.last_digest_sent_at = utcnow()
+    db.session.commit()
+
+    monkeypatch.setattr(email_service, "send", lambda **k: True)
+    assert digest.send_for_user(user.id) is False
+
+
+def test_send_for_user_raises_for_retry_on_smtp_failure(
+    monkeypatch, db, user, workspace, uploaded_file,
+):
+    """Real SMTP outages should bubble as DigestSendFailed so the jobs
+    queue retries instead of marking the digest as sent."""
+    from filenergy.services import digest, email as email_service
+
+    monkeypatch.setattr(email_service, "send", lambda to, subject, body: False)
+    with pytest.raises(digest.DigestSendFailed):
+        digest.send_for_user(user.id)
+    db.session.refresh(user)
+    assert user.last_digest_sent_at is None
+
+
+# ---------- Tailwind bundle switch --------------------------------------
+
+
+def test_base_uses_compiled_bundle_when_present(client, app, monkeypatch, tmp_path):
+    """When static/css/app.css exists, base.html links to it instead of
+    pulling the Play CDN."""
+    import os, shutil
+    from pathlib import Path
+
+    bundle_path = Path(app.static_folder) / "css" / "app.css"
+    bundle_path.parent.mkdir(parents=True, exist_ok=True)
+    bundle_path.write_text("/* compiled */", encoding="utf-8")
+    try:
+        r = client.get("/")
+        assert r.status_code == 200
+        assert b"/static/css/app.css" in r.data
+        assert b"cdn.tailwindcss.com" not in r.data
+    finally:
+        os.remove(bundle_path)
+
+
+def test_base_falls_back_to_cdn_without_bundle(client, app):
+    """Default dev path: no bundle file → CDN + inline component classes."""
+    import os
+    from pathlib import Path
+
+    bundle_path = Path(app.static_folder) / "css" / "app.css"
+    if bundle_path.exists():
+        os.remove(bundle_path)
+    r = client.get("/")
+    assert r.status_code == 200
+    assert b"cdn.tailwindcss.com" in r.data


### PR DESCRIPTION
## Summary

- **Real WebAuthn ceremony** via `py_webauthn`: server builds creation/request options, stashes the challenge in the Flask session, verifies attestation + assertion. Browser JS drives `navigator.credentials.create/get`. Stub flow preserved for tests / pre-JS deploys. Wired into both registration (`/settings/security/webauthn/{begin,complete}`) and login (`/user/2fa/webauthn/{begin,complete}`).
- **Compiled Tailwind for production**: multi-stage Dockerfile (Node compiles `app.css.min`, Python runtime serves it), `package.json` + `tailwind.config.js` + `tailwind.src.css`. `base.html` switches between bundle and Play CDN based on file presence. CSP drops `'unsafe-eval'` and the CDN host when the bundle is in use.
- **Retry-aware jobs queue**: `jobs.enqueue(..., retries=N, retry_backoff_seconds=B)` for sync / thread / RQ modes (RQ uses `rq.Retry` natively). Webhook deliveries retry 4× on 5xx + network errors (4xx is one-shot, since retrying a consumer payload bug just hammers them). Digest gets async fan-out via `digest.send_pending(async_dispatch=True)` and a per-user `send_for_user` job.

## Test plan

- [x] 786 tests passing
- [x] Coverage 96.0% (≥95% bar held)
- [x] New `tests/test_tier4_features.py` covers full ceremony, sync/thread/RQ retry paths, 5xx vs 4xx semantics, digest async fan-out, Tailwind bundle switch
- [x] `requirements.txt` adds `webauthn>=2.5`


---
_Generated by [Claude Code](https://claude.ai/code/session_01V5mfhSQRZzyNxdsNx1ybWN)_