### PR TITLE
Tier 7: ship-day polish — landing, reranking, SCIM, email-to-ingest, undo, pin/archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,25 @@ the Anthropic Claude API for answers, and Stripe Checkout for billing.
 **Answer-quality dashboard (thumbs feedback over time + triage queue)**
 ![Evals](docs/screenshots/evals.svg)
 
+## What's new in this release
+
+- **Reranking on top of vector search** — every retrieval pulls a wider
+  candidate set, then a fast Claude pass scores each chunk 0–10 against
+  the query. Disable with `FILENERGY_RERANKER=noop`.
+- **SCIM 2.0** at `/scim/v2/*` — provision and de-provision users from
+  Okta, Workspace, Auth0, Azure AD. Bearer-token auth +
+  `X-Filenergy-Workspace-Slug` header.
+- **Email-to-ingest** — every workspace gets a deterministic
+  `inbox-<slug>-<token>@<domain>` address. Forward an email and the
+  body + attachments become indexed files.
+- **Soft-delete with undo** — bulk-delete shows a toast with an Undo
+  button for 8 seconds. Files only get hard-deleted after a grace
+  window (`flask purge-deleted-files` runs from cron).
+- **Conversation pinning + archiving** — pinned threads float to the
+  top of the sidebar; archived threads are hidden but kept for export.
+- **File rename**, **collection share links**, command-palette
+  arrow-key navigation, redesigned landing page.
+
 ## UX
 
 - **Command palette** (⌘K / Ctrl+K / `/`) — quick-jump to any page,

--- a/filenergy/__init__.py
+++ b/filenergy/__init__.py
@@ -50,3 +50,26 @@ def _send_digests_cli():
     n = digest.send_pending()
     print(f"sent {n} digest(s)")
 
+
+# CLI: purge files that were soft-deleted more than the grace window ago.
+# Run hourly from cron / k8s. The grace window is FILENERGY_DELETE_GRACE_HOURS.
+@app.cli.command("purge-deleted-files")
+def _purge_deleted_files_cli():
+    from datetime import timedelta
+    from filenergy.models import File, utcnow
+    from filenergy.services.file import FileService
+
+    grace_hours = int(os.environ.get("FILENERGY_DELETE_GRACE_HOURS", "24"))
+    cutoff = utcnow() - timedelta(hours=grace_hours)
+    rows = (
+        File.query
+        .filter(File.deleted_at.isnot(None), File.deleted_at < cutoff)
+        .all()
+    )
+    svc = FileService()
+    purged = 0
+    for f in rows:
+        if svc.delete(f):
+            purged += 1
+    print(f"purged {purged} file(s) past {grace_hours}h grace")
+

--- a/filenergy/models/__init__.py
+++ b/filenergy/models/__init__.py
@@ -222,6 +222,10 @@ class File(BaseModel):
     text_content = db.Column(EncryptedText, nullable=True)
     summary = db.Column(db.Text, nullable=True)
     suggested_questions_json = db.Column(db.Text, nullable=True)
+    # Soft-delete: set when the user clicks Delete; a periodic purge job
+    # hard-deletes rows older than the grace window. Letting users Undo
+    # a destructive action is worth one extra column.
+    deleted_at = db.Column(db.DateTime, nullable=True, index=True)
 
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"))
     workspace_id = db.Column(
@@ -323,6 +327,10 @@ class Conversation(BaseModel):
         db.Integer, db.ForeignKey("workspace.id"), index=True
     )
     title = db.Column(db.String(255))
+    # Pinned threads float to the top of the sidebar; archived threads
+    # are hidden by default but kept for audit + GDPR exports.
+    pinned_at = db.Column(db.DateTime, nullable=True)
+    archived_at = db.Column(db.DateTime, nullable=True)
 
     user = db.relationship(
         "User", foreign_keys=[user_id],
@@ -497,6 +505,38 @@ class ConversationShareLink(BaseModel):
     view_count = db.Column(db.Integer, default=0)
 
     conversation = db.relationship("Conversation")
+    created_by = db.relationship("User")
+
+    def is_active(self, *, now=None) -> bool:
+        if self.revoked_at is not None:
+            return False
+        now = now or utcnow()
+        if self.expires_at is not None and now >= self.expires_at:
+            return False
+        return True
+
+
+class CollectionShareLink(BaseModel):
+    """Public read-only listing of an entire Collection.
+
+    Different from `ShareLink` (one file) and `ConversationShareLink`
+    (one thread): exposes every indexed file in the collection at
+    `/sl/<token>` with download links that respect TTL + revocation.
+    """
+
+    __tablename__ = "collection_share_link"
+
+    id = db.Column(db.Integer, primary_key=True)
+    collection_id = db.Column(
+        db.Integer, db.ForeignKey("collection.id"), index=True,
+    )
+    token = db.Column(db.String(64), unique=True, index=True)
+    expires_at = db.Column(db.DateTime, nullable=True)
+    revoked_at = db.Column(db.DateTime, nullable=True)
+    created_by_id = db.Column(db.Integer, db.ForeignKey("user.id"))
+    view_count = db.Column(db.Integer, default=0)
+
+    collection = db.relationship("Collection")
     created_by = db.relationship("User")
 
     def is_active(self, *, now=None) -> bool:

--- a/filenergy/services/billing.py
+++ b/filenergy/services/billing.py
@@ -44,13 +44,19 @@ def storage_used_bytes(workspace: Workspace) -> int:
     total = (
         db.session.query(db.func.coalesce(db.func.sum(File.size_bytes), 0))
         .filter(File.workspace_id == workspace.id)
+        .filter(File.deleted_at.is_(None))
         .scalar()
     )
     return int(total or 0)
 
 
 def files_count(workspace: Workspace) -> int:
-    return File.query.filter_by(workspace_id=workspace.id).count()
+    return (
+        File.query
+        .filter_by(workspace_id=workspace.id)
+        .filter(File.deleted_at.is_(None))
+        .count()
+    )
 
 
 def asks_this_month(workspace: Workspace) -> int:

--- a/filenergy/services/chat.py
+++ b/filenergy/services/chat.py
@@ -141,10 +141,21 @@ def _build_messages(
 def _retrieve(workspace, question: str, *,
               collection_id: int | None = None,
               file_id: int | None = None):
-    return embeddings.search(
-        workspace, question, settings.RETRIEVAL_K,
+    """Two-stage retrieval: embedding recall, then optional LLM rerank.
+
+    We pull a wider candidate set than RETRIEVAL_K (so the reranker has
+    something to choose from), then let `reranker.rerank` cut down to
+    the final top-K by precision. When the reranker is disabled, the
+    raw embedding ranking is used.
+    """
+    from filenergy.services import reranker
+
+    candidate_k = max(settings.RETRIEVAL_K, 12) if reranker.is_enabled() else settings.RETRIEVAL_K
+    candidates = embeddings.search(
+        workspace, question, candidate_k,
         collection_id=collection_id, file_id=file_id,
     )
+    return reranker.rerank(question, candidates)
 
 
 def _no_results_message() -> str:

--- a/filenergy/services/conversations.py
+++ b/filenergy/services/conversations.py
@@ -31,10 +31,21 @@ def get_or_create(user, workspace, conversation_id: int | None) -> Conversation:
     return conv
 
 
-def list_for_user(user, workspace) -> list[Conversation]:
+def list_for_user(
+    user, workspace, *, include_archived: bool = False,
+) -> list[Conversation]:
+    """Return the user's conversations in sidebar order: pinned first,
+    then most-recent. Archived threads are hidden by default."""
+    q = Conversation.query.filter_by(
+        user_id=user.id, workspace_id=workspace.id,
+    )
+    if not include_archived:
+        q = q.filter(Conversation.archived_at.is_(None))
     return (
-        Conversation.query.filter_by(user_id=user.id, workspace_id=workspace.id)
-        .order_by(Conversation.id.desc())
+        q.order_by(
+            Conversation.pinned_at.is_(None),  # NULL last → pinned first
+            Conversation.id.desc(),
+        )
         .limit(50)
         .all()
     )

--- a/filenergy/services/embeddings.py
+++ b/filenergy/services/embeddings.py
@@ -80,6 +80,7 @@ def search(
     q = (
         Chunk.query.join(File, Chunk.file_id == File.id)
         .filter(File.workspace_id == workspace.id)
+        .filter(File.deleted_at.is_(None))
         .filter(Chunk.embedding.isnot(None))
     )
     if file_id is not None:

--- a/filenergy/services/inbound_email.py
+++ b/filenergy/services/inbound_email.py
@@ -1,0 +1,167 @@
+"""Email-to-ingest.
+
+Each workspace gets a deterministic inbound address derived from its
+slug + a shared secret:
+
+    inbox-<slug>-<token>@<FILENERGY_INBOUND_DOMAIN>
+
+Inbound providers (Postmark, SendGrid, Mailgun, Cloudflare Email
+Workers) POST a JSON or multipart payload to `/inbound/email`. We
+parse the To address, look up the workspace, and ingest the body +
+each attachment as separate files.
+
+The token is derived as `HMAC-SHA256(workspace.slug, INBOUND_SECRET)[:12]`
+so a leak of one address doesn't help an attacker guess another. The
+endpoint also supports a shared-secret header (`X-Inbound-Secret`) for
+providers that allow it.
+
+Disabled until both `FILENERGY_INBOUND_DOMAIN` and
+`FILENERGY_INBOUND_SECRET` are set.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import logging
+import os
+import re
+
+from filenergy import db
+from filenergy.models import File, Workspace
+from filenergy.services import billing, events, ingestion
+
+log = logging.getLogger(__name__)
+
+
+def is_configured() -> bool:
+    return bool(
+        os.environ.get("FILENERGY_INBOUND_DOMAIN")
+        and os.environ.get("FILENERGY_INBOUND_SECRET")
+    )
+
+
+def _domain() -> str:
+    return os.environ.get("FILENERGY_INBOUND_DOMAIN", "")
+
+
+def _secret() -> bytes:
+    return os.environ.get("FILENERGY_INBOUND_SECRET", "").encode("utf-8")
+
+
+def address_for(workspace: Workspace) -> str:
+    """Return the per-workspace inbound address. Display this in
+    Settings → Workspace so users know where to forward email."""
+    if not is_configured():
+        return ""
+    token = hmac.new(_secret(), workspace.slug.encode("utf-8"), hashlib.sha256)
+    short = token.hexdigest()[:12]
+    return f"inbox-{workspace.slug}-{short}@{_domain()}"
+
+
+_LOCAL_RE = re.compile(r"^inbox-(?P<slug>[^@]+?)-(?P<token>[a-f0-9]{12})$")
+
+
+def _resolve_workspace(to_address: str) -> Workspace | None:
+    """Parse `inbox-<slug>-<token>@<domain>` and return the workspace,
+    or None if the slug or token doesn't match. Constant-time compare
+    on the token guards against forgery via timing."""
+    if not is_configured() or "@" not in to_address:
+        return None
+    local, _, domain = to_address.lower().partition("@")
+    if domain != _domain().lower():
+        return None
+    m = _LOCAL_RE.match(local)
+    if not m:
+        return None
+    slug = m.group("slug")
+    presented = m.group("token")
+    ws = Workspace.query.filter_by(slug=slug).first()
+    if ws is None:
+        return None
+    expected = hmac.new(_secret(), slug.encode("utf-8"), hashlib.sha256).hexdigest()[:12]
+    if not hmac.compare_digest(expected, presented):
+        return None
+    return ws
+
+
+def ingest_payload(payload: dict) -> dict:
+    """Process an inbound provider payload. Provider-agnostic shape:
+
+        {
+            "to":      "inbox-acme-abc123@filenergy.io",
+            "from":    "alice@example.com",
+            "subject": "Q4 contract draft",
+            "text":    "Body of the email...",
+            "html":    "<p>...</p>",
+            "attachments": [
+                {"filename": "draft.pdf", "content": "<base64>",
+                 "content_type": "application/pdf"},
+            ],
+        }
+    """
+    to_addr = (payload.get("to") or "").strip()
+    workspace = _resolve_workspace(to_addr)
+    if workspace is None:
+        return {"ok": False, "error": "no matching workspace"}
+
+    from_addr = (payload.get("from") or "").strip()
+    subject = (payload.get("subject") or "Email").strip()[:200]
+    body_text = payload.get("text") or ""
+    attachments = payload.get("attachments") or []
+    if not isinstance(attachments, list):
+        attachments = []
+
+    user = workspace.owner
+    created: list[int] = []
+
+    # 1) Body — only if it has substantive text. Save as `<subject>.md`.
+    if body_text and body_text.strip():
+        try:
+            billing.ensure_can_upload(workspace)
+            md = f"# {subject}\n\n_From: {from_addr}_\n\n{body_text}"
+            f = ingestion.ingest_text(
+                user=user, workspace=workspace,
+                name=f"{subject}.md",
+                content_bytes=md.encode("utf-8"),
+                source="email",
+            )
+            created.append(f.id)
+        except billing.QuotaExceeded:
+            pass
+        except Exception:
+            log.exception("Failed to ingest email body")
+
+    # 2) Attachments — each becomes its own file.
+    for att in attachments:
+        if not isinstance(att, dict):
+            continue
+        filename = (att.get("filename") or "attachment").strip()
+        b64 = att.get("content") or ""
+        if not filename or not b64:
+            continue
+        try:
+            data = base64.b64decode(b64)
+        except Exception:
+            continue
+        if len(data) > 10 * 1024 * 1024:  # 10 MB hard cap
+            continue
+        try:
+            billing.ensure_can_upload(workspace)
+            f = ingestion.ingest_text(
+                user=user, workspace=workspace,
+                name=filename, content_bytes=data, source="email",
+            )
+            created.append(f.id)
+        except billing.QuotaExceeded:
+            break
+        except Exception:
+            log.exception("Failed to ingest attachment %s", filename)
+
+    events.log_event(
+        events.FILE_UPLOADED,
+        user=user, workspace_id=workspace.id,
+        source="email", from_address=from_addr,
+        ingested_count=len(created),
+    )
+    return {"ok": True, "ingested": len(created), "ids": created}

--- a/filenergy/services/ingestion.py
+++ b/filenergy/services/ingestion.py
@@ -165,6 +165,31 @@ def materialize_blob(
     return db_file
 
 
+def ingest_text(
+    *, user, workspace, name: str, content_bytes: bytes,
+    source: str = "ingestion",
+    sync_index: bool | None = None,
+) -> File:
+    """Persist arbitrary bytes as a new File and index it asynchronously.
+
+    Used by the email-to-ingest endpoint and the URL fetcher to push
+    content into the library through the same code path as a manual
+    upload.
+    """
+    from filenergy.services.file import FileService
+
+    f = materialize_blob(
+        user=user, workspace=workspace, name=name, content=content_bytes,
+    )
+    if sync_index is None:
+        sync_index = settings.SYNC_INDEXING or app.config.get("TESTING", False)
+    if sync_index:
+        FileService().index_file(f)
+    else:
+        _async_index(f.id)
+    return f
+
+
 def ingest_url(*, user, workspace, url: str, sync_index: bool | None = None) -> File:
     """End-to-end: fetch a URL, persist it, kick off indexing."""
     name, text, raw = fetch_url(url)

--- a/filenergy/services/reranker.py
+++ b/filenergy/services/reranker.py
@@ -1,0 +1,152 @@
+"""LLM-based reranking on top of embedding retrieval.
+
+Embeddings get you a *recall* layer — you pull back roughly-relevant
+chunks fast. They're not great at *precision* — figuring out which 4
+of 20 candidates actually answer the question. A small cross-encoder
+or LLM re-scoring pass on the top-K cuts the chaff before grounding.
+
+Two backends:
+
+  - "claude" (default when ANTHROPIC_API_KEY is set) — sends every
+    candidate + the query as a single prompt and asks Claude Haiku for
+    a 0-10 score per chunk. Cheap because we use the small/fast model
+    and structured output.
+  - "noop" — return the input unchanged. Lets self-hosted operators
+    disable the extra round-trip. Set FILENERGY_RERANKER=noop.
+
+Tunables:
+  - FILENERGY_RERANKER=claude|noop          (default: claude)
+  - FILENERGY_RERANKER_MODEL=claude-haiku-4-5-20251001
+  - FILENERGY_RERANK_TOP_K=4                (results to keep)
+  - FILENERGY_RERANK_CANDIDATES=20          (max sent to the reranker)
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+
+def _backend() -> str:
+    return (os.environ.get("FILENERGY_RERANKER") or "claude").lower()
+
+
+def _model() -> str:
+    return os.environ.get("FILENERGY_RERANKER_MODEL", "claude-haiku-4-5-20251001")
+
+
+def _top_k() -> int:
+    try:
+        return int(os.environ.get("FILENERGY_RERANK_TOP_K", "4"))
+    except (TypeError, ValueError):
+        return 4
+
+
+def _candidates_cap() -> int:
+    try:
+        return int(os.environ.get("FILENERGY_RERANK_CANDIDATES", "20"))
+    except (TypeError, ValueError):
+        return 20
+
+
+def is_enabled() -> bool:
+    """Whether the active backend can actually rank.
+
+    Claude backend needs `ANTHROPIC_API_KEY`; noop is always available
+    but is a passthrough.
+    """
+    backend = _backend()
+    if backend == "noop":
+        return False
+    if backend == "claude":
+        from filenergy import settings
+        return bool(getattr(settings, "ANTHROPIC_API_KEY", None))
+    return False
+
+
+def rerank(query: str, candidates: list) -> list:
+    """Re-score `candidates` (list of `(Chunk, score)` tuples) and return
+    the top-K by the reranker's verdict. Falls through unchanged if the
+    backend is disabled or errors.
+
+    The order of the output is the new ranking; entries below cut-off
+    are dropped.
+    """
+    if not candidates:
+        return candidates
+    if not is_enabled():
+        return candidates[:_top_k()]
+
+    backend = _backend()
+    if backend == "claude":
+        try:
+            return _rerank_claude(query, candidates)
+        except Exception:
+            log.exception("Claude reranker failed; falling back to embeddings order")
+            return candidates[:_top_k()]
+    return candidates[:_top_k()]
+
+
+def _rerank_claude(query: str, candidates: list) -> list:
+    """Use the small/fast Claude model to score every candidate 0-10
+    against the query. We send a single message with all candidates so
+    the model can read them in context (reranking is cross-attention).
+    """
+    from filenergy.services.chat import _client
+
+    capped = candidates[: _candidates_cap()]
+    numbered = []
+    for i, (chunk, _emb_score) in enumerate(capped):
+        text = (chunk.content or "")[:600]
+        numbered.append(f"<chunk id=\"{i}\">{text}</chunk>")
+
+    prompt = (
+        "You score document chunks for relevance to a user query.\n"
+        "Return STRICT JSON like {\"scores\":[{\"id\":0,\"score\":7},...]}\n"
+        "score is an integer 0-10; 0 = unrelated, 10 = directly answers.\n\n"
+        f"<query>{query}</query>\n\n"
+        + "\n".join(numbered)
+    )
+
+    msg = _client().messages.create(
+        model=_model(),
+        max_tokens=512,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    text = "".join(
+        b.text for b in msg.content
+        if getattr(b, "type", None) == "text"
+    ).strip()
+
+    # The model sometimes wraps JSON in ```json fences.
+    if text.startswith("```"):
+        text = text.split("```", 2)[1]
+        if text.startswith("json"):
+            text = text[4:]
+        text = text.strip("`\n ")
+
+    try:
+        parsed = json.loads(text)
+        scores = parsed.get("scores", [])
+    except Exception:
+        log.warning("Reranker returned non-JSON: %s", text[:200])
+        return candidates[: _top_k()]
+
+    by_id: dict[int, int] = {}
+    for entry in scores:
+        try:
+            by_id[int(entry["id"])] = int(entry["score"])
+        except (KeyError, TypeError, ValueError):
+            continue
+
+    # Pair each candidate with its rerank score (default 0 if missing).
+    rescored = []
+    for i, (chunk, emb_score) in enumerate(capped):
+        rescored.append(((chunk, emb_score), by_id.get(i, 0)))
+
+    # Sort descending by reranker score; embedding score breaks ties so
+    # the original order is preserved when the model can't differentiate.
+    rescored.sort(key=lambda x: (x[1], x[0][1]), reverse=True)
+    return [pair for pair, _ in rescored[: _top_k()]]

--- a/filenergy/services/search.py
+++ b/filenergy/services/search.py
@@ -59,6 +59,7 @@ def search(workspace, query: str, *, limit: int = 6) -> list[dict]:
     file_q = (
         File.query
         .filter(File.workspace_id == workspace.id)
+        .filter(File.deleted_at.is_(None))
         .filter(File.name.ilike(f"%{q}%"))
         .order_by(File.id.desc())
         .limit(limit)

--- a/filenergy/static/img/landing-chat.svg
+++ b/filenergy/static/img/landing-chat.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 720" font-family="ui-sans-serif, system-ui, sans-serif">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f8fafc"/>
+      <stop offset="100%" stop-color="#eff6ff"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#0f172a" flood-opacity="0.06"/>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="720" fill="url(#bg)"/>
+
+  <!-- Window chrome -->
+  <rect x="40" y="40" width="1120" height="640" rx="14" fill="#ffffff" stroke="#e2e8f0" filter="url(#shadow)"/>
+  <rect x="40" y="40" width="1120" height="40" rx="14" fill="#f8fafc"/>
+  <circle cx="64" cy="60" r="6" fill="#f87171"/>
+  <circle cx="84" cy="60" r="6" fill="#fbbf24"/>
+  <circle cx="104" cy="60" r="6" fill="#34d399"/>
+  <text x="600" y="64" font-size="11" fill="#94a3b8" text-anchor="middle">filenergy.app/ask</text>
+
+  <!-- Top bar inside app -->
+  <rect x="40" y="80" width="1120" height="56" fill="#ffffff" stroke="#e2e8f0"/>
+  <rect x="60" y="98" width="20" height="20" rx="4" fill="#2563eb"/>
+  <text x="88" y="112" font-size="14" font-weight="600" fill="#0f172a">Filenergy</text>
+  <text x="220" y="112" font-size="13" fill="#0f172a" font-weight="500">Ask</text>
+  <text x="280" y="112" font-size="13" fill="#64748b">Files</text>
+  <text x="340" y="112" font-size="13" fill="#64748b">Collections</text>
+  <text x="430" y="112" font-size="13" fill="#64748b">Connectors</text>
+  <text x="540" y="112" font-size="13" fill="#64748b">Dashboard</text>
+  <rect x="850" y="94" width="180" height="28" rx="6" fill="none" stroke="#e2e8f0"/>
+  <text x="868" y="112" font-size="12" fill="#94a3b8">Search…</text>
+  <rect x="998" y="98" width="26" height="20" rx="4" fill="#f1f5f9"/>
+  <text x="1004" y="112" font-size="11" fill="#475569" font-family="monospace">⌘K</text>
+  <rect x="1056" y="94" width="68" height="28" rx="999" fill="#dbeafe"/>
+  <text x="1072" y="112" font-size="11" font-weight="500" fill="#1e40af">acme · pro</text>
+
+  <!-- Sidebar -->
+  <rect x="40" y="136" width="240" height="544" fill="#ffffff" stroke="#e2e8f0"/>
+  <rect x="60" y="156" width="200" height="40" rx="8" fill="#2563eb"/>
+  <text x="92" y="180" font-size="13" font-weight="500" fill="#ffffff">+ New conversation</text>
+  <rect x="60" y="208" width="200" height="32" rx="6" fill="none" stroke="#e2e8f0"/>
+  <text x="76" y="228" font-size="12" fill="#94a3b8">Filter conversations…</text>
+  <text x="60" y="266" font-size="10" font-weight="600" fill="#94a3b8" letter-spacing="1">RECENT</text>
+  <rect x="60" y="276" width="200" height="34" rx="6" fill="#f1f5f9"/>
+  <text x="76" y="297" font-size="13" fill="#0f172a" font-weight="500">Q4 contract review</text>
+  <text x="76" y="332" font-size="13" fill="#475569">Onboarding deck feedback</text>
+  <text x="76" y="362" font-size="13" fill="#475569">2026 OKR drafts</text>
+  <text x="76" y="392" font-size="13" fill="#475569">RFP — Acme procurement</text>
+  <text x="76" y="422" font-size="13" fill="#475569">Customer interview wk 31</text>
+  <text x="76" y="452" font-size="13" fill="#475569">Vendor X — termination</text>
+  <text x="76" y="482" font-size="13" fill="#475569">Pricing model v3</text>
+
+  <!-- Thread header -->
+  <rect x="300" y="156" width="840" height="48" rx="10" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="320" y="186" font-size="14" font-weight="500" fill="#0f172a">Q4 contract review</text>
+  <text x="320" y="200" font-size="11" fill="#94a3b8">Saved · 2 messages</text>
+  <rect x="1050" y="166" width="80" height="28" rx="6" fill="none" stroke="#e2e8f0"/>
+  <text x="1070" y="184" font-size="12" fill="#475569">Export</text>
+
+  <!-- Thread body -->
+  <rect x="300" y="220" width="840" height="380" rx="12" fill="#ffffff" stroke="#e2e8f0"/>
+
+  <!-- User bubble -->
+  <rect x="380" y="244" width="740" height="58" rx="10" fill="#eff6ff"/>
+  <text x="404" y="270" font-size="14" fill="#1e40af" font-weight="500">You</text>
+  <text x="404" y="290" font-size="13" fill="#1e3a8a">Summarize the termination clauses across all our SaaS contracts.</text>
+
+  <!-- Assistant bubble -->
+  <rect x="320" y="318" width="740" height="262" rx="10" fill="#f8fafc" stroke="#e2e8f0"/>
+  <text x="344" y="346" font-size="14" font-weight="500" fill="#0f172a">Assistant</text>
+
+  <!-- Markdown-rendered body -->
+  <text x="344" y="374" font-size="13" fill="#0f172a" font-weight="500">3 of 4 contracts permit termination for convenience with 30 days' notice.</text>
+  <text x="344" y="396" font-size="13" fill="#334155">The Acme MSA additionally allows immediate termination on a material</text>
+  <text x="344" y="416" font-size="13" fill="#334155">breach (§9.2). Notable holdouts:</text>
+  <text x="364" y="438" font-size="13" fill="#334155">• Vendor-X — locks you in for 24 months, no opt-out.</text>
+  <text x="364" y="458" font-size="13" fill="#334155">• OldCo — silent on termination; default common-law rules apply.</text>
+  <text x="344" y="488" font-size="13" fill="#0f172a" font-weight="500">Recommendation:</text>
+  <text x="344" y="510" font-size="13" fill="#334155">Add an opt-out rider before next renewal on Vendor-X.</text>
+
+  <!-- Sources -->
+  <text x="344" y="540" font-size="11" fill="#64748b">Sources:</text>
+  <rect x="392" y="528" width="100" height="20" rx="4" fill="#eff6ff"/>
+  <text x="402" y="542" font-size="11" fill="#1e40af">Acme MSA.pdf</text>
+  <rect x="500" y="528" width="100" height="20" rx="4" fill="#eff6ff"/>
+  <text x="510" y="542" font-size="11" fill="#1e40af">Vendor-X.pdf</text>
+  <rect x="608" y="528" width="76" height="20" rx="4" fill="#eff6ff"/>
+  <text x="618" y="542" font-size="11" fill="#1e40af">OldCo.docx</text>
+
+  <!-- Hover actions -->
+  <g transform="translate(992 552)">
+    <rect width="22" height="22" rx="4" fill="#ffffff" stroke="#e2e8f0"/>
+    <path d="M9 7h6v8H9z M5 11h6v8H5z" stroke="#94a3b8" stroke-width="1.4" fill="none" transform="translate(0 0)"/>
+    <rect x="26" width="22" height="22" rx="4" fill="#ffffff" stroke="#e2e8f0"/>
+    <path d="M30 17v-7l4 8h4l-2-9h-6z" stroke="#10b981" stroke-width="1.4" fill="none" transform="translate(2 0)"/>
+    <rect x="52" width="22" height="22" rx="4" fill="#ffffff" stroke="#e2e8f0"/>
+    <path d="M62 14a4 4 0 1 0-8 0 4 4 0 0 0 8 0z" stroke="#94a3b8" stroke-width="1.4" fill="none"/>
+  </g>
+
+  <!-- Composer -->
+  <rect x="300" y="616" width="840" height="56" rx="10" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="324" y="650" font-size="13" fill="#94a3b8">Ask anything about your library — paste an image to add vision...</text>
+  <rect x="1010" y="630" width="50" height="28" rx="6" fill="none" stroke="#e2e8f0"/>
+  <text x="1030" y="648" font-size="11" fill="#64748b">Stop</text>
+  <rect x="1066" y="630" width="56" height="28" rx="6" fill="#2563eb"/>
+  <text x="1083" y="648" font-size="13" font-weight="500" fill="#ffffff">Send</text>
+</svg>

--- a/filenergy/templates/ask/index.html
+++ b/filenergy/templates/ask/index.html
@@ -16,10 +16,16 @@
     <h4 class="mt-3 text-xs font-semibold uppercase tracking-wide text-slate-500">Recent</h4>
     <nav id="conv-list" class="space-y-1">
       {% for c in conversations %}
-        <a href="/ask/c/{{c.id}}" data-title="{{ c.title or 'Untitled' }}"
-           class="conv-link {% if active_conversation and active_conversation.id == c.id %}nav-link-active{% else %}nav-link{% endif %} truncate text-sm">
-          {{ c.title or 'Untitled' }}
-        </a>
+        <div class="group relative" data-conv-id="{{ c.id }}">
+          <a href="/ask/c/{{c.id}}" data-title="{{ c.title or 'Untitled' }}"
+             class="conv-link {% if active_conversation and active_conversation.id == c.id %}nav-link-active{% else %}nav-link{% endif %} truncate pr-8 text-sm">
+            {% if c.pinned_at %}<span class="mr-1 text-amber-500">★</span>{% endif %}
+            {{ c.title or 'Untitled' }}
+          </a>
+          <button type="button" class="conv-menu-btn absolute right-1 top-1 hidden rounded p-1 text-slate-400 hover:bg-slate-200 hover:text-slate-700 group-hover:block"
+                  data-conv-id="{{ c.id }}" data-pinned="{{ '1' if c.pinned_at else '' }}"
+                  title="More options">⋯</button>
+        </div>
       {% else %}
         <p class="text-xs text-slate-400">No threads yet.</p>
       {% endfor %}
@@ -410,11 +416,36 @@
     if ($b.children().length === 0) { $b.html(renderMarkdown($b.text())); }
   });
 
+  // Conversation actions menu (pin / archive).
+  $(document).on('click', '.conv-menu-btn', function(e) {
+    e.preventDefault(); e.stopPropagation();
+    var $btn = $(this);
+    var convId = $btn.data('conv-id');
+    var pinned = !!$btn.data('pinned');
+    $('.conv-menu').remove();
+    var $menu = $(
+      '<div class="conv-menu absolute right-1 top-7 z-20 w-36 rounded-md border border-slate-200 bg-white py-1 text-sm shadow-lg">' +
+        '<button type="button" data-action="pin"     class="block w-full px-3 py-1.5 text-left hover:bg-slate-50">' + (pinned ? 'Unpin' : 'Pin') + '</button>' +
+        '<button type="button" data-action="archive" class="block w-full px-3 py-1.5 text-left hover:bg-slate-50">Archive</button>' +
+      '</div>'
+    );
+    $btn.parent().append($menu);
+    $menu.find('button').on('click', function() {
+      var action = $(this).data('action');
+      $.post('/ask/c/' + convId + '/' + action).done(function() {
+        location.reload();
+      }).fail(function() { window.fnToast('Could not update', 'error'); });
+    });
+  });
+  // Click-outside dismisses any open conversation menu.
+  $(document).on('click', function() { $('.conv-menu').remove(); });
+
   $('#conv-filter').on('input', function() {
     var q = $(this).val().toLowerCase();
     $('#conv-list .conv-link').each(function() {
-      var t = ($(this).attr('data-title') || '').toLowerCase();
-      $(this).toggle(!q || t.indexOf(q) >= 0);
+      var $a = $(this);
+      var t = ($a.attr('data-title') || '').toLowerCase();
+      $a.closest('[data-conv-id]').toggle(!q || t.indexOf(q) >= 0);
     });
   });
 

--- a/filenergy/templates/base.html
+++ b/filenergy/templates/base.html
@@ -262,6 +262,22 @@
       {% if g.user.is_authenticated %}
       var $cmdk = null;
       var cmdkAbort = null;
+      var cmdkActive = 0;     // index of the currently-highlighted row
+      var cmdkLinks = [];     // jQuery objects, one per result row
+
+      function highlightCmdkRow(idx) {
+        cmdkLinks.forEach(function($a, i) {
+          $a.toggleClass('bg-brand-50 text-brand-700', i === idx)
+            .toggleClass('hover:bg-slate-50', i !== idx);
+        });
+        if (cmdkLinks[idx]) {
+          var node = cmdkLinks[idx][0];
+          if (node && node.scrollIntoView) {
+            node.scrollIntoView({block: 'nearest'});
+          }
+        }
+      }
+
       function openCmdK() {
         if ($cmdk) { $cmdk.find('input').focus(); return; }
         $cmdk = $(
@@ -273,29 +289,42 @@
                 '<span class="kbd">esc</span>' +
               '</div>' +
               '<ul class="cmdk-results max-h-80 overflow-y-auto py-1 text-sm"></ul>' +
+              '<div class="border-t border-slate-100 px-3 py-1.5 text-xs text-slate-400 flex justify-between">' +
+                '<span><span class="kbd">↑↓</span> navigate · <span class="kbd">↵</span> open</span>' +
+                '<span><span class="kbd">esc</span> close</span>' +
+              '</div>' +
             '</div>' +
           '</div>'
         );
         $('body').append($cmdk);
         function render(items) {
           var $ul = $cmdk.find('.cmdk-results').empty();
+          cmdkLinks = [];
+          cmdkActive = 0;
           if (!items.length) {
             $ul.append('<li class="px-4 py-3 text-slate-500">No matches.</li>');
             return;
           }
           items.forEach(function(c, i) {
-            var subtitle = c.subtitle ? '<span class="ml-auto text-xs text-slate-400">' + c.subtitle + '</span>' : '';
+            var subtitle = c.subtitle ? '<span class="ml-auto text-xs text-slate-400">' + $('<div>').text(c.subtitle).html() + '</span>' : '';
             var $li = $(
               '<li>' +
-                '<a href="' + c.href + '" class="flex items-center gap-3 px-4 py-2 ' + (i === 0 ? 'bg-brand-50 text-brand-700' : 'hover:bg-slate-50') + '">' +
+                '<a href="' + c.href + '" class="flex items-center gap-3 px-4 py-2">' +
                   '<svg class="icon"><use href="#' + (c.icon || 'i-search') + '"/></svg>' +
-                  '<span>' + $('<div>').text(c.label).html() + '</span>' +
+                  '<span class="truncate">' + $('<div>').text(c.label).html() + '</span>' +
                   subtitle +
                 '</a>' +
               '</li>'
             );
             $ul.append($li);
+            var $a = $li.find('a');
+            cmdkLinks.push($a);
+            $a.on('mouseenter', function() {
+              cmdkActive = i;
+              highlightCmdkRow(i);
+            });
           });
+          highlightCmdkRow(0);
         }
         function fetchResults(q) {
           if (cmdkAbort) cmdkAbort.abort();
@@ -303,18 +332,31 @@
             url: '/search', method: 'GET', data: {q: q},
           }).done(function(resp) { render(resp.results || []); });
         }
-        // Initial render: nav-only.
         fetchResults('');
         var debounceTimer = null;
-        $cmdk.find('input').on('input', function() {
+        var $input = $cmdk.find('input');
+        $input.on('input', function() {
           var q = $(this).val();
           clearTimeout(debounceTimer);
           debounceTimer = setTimeout(function(){ fetchResults(q); }, 120);
         }).focus();
-        $cmdk.find('input').on('keydown', function(e) {
-          if (e.key === 'Enter') {
-            var first = $cmdk.find('.cmdk-results a').first();
-            if (first.length) { location.href = first.attr('href'); }
+        $input.on('keydown', function(e) {
+          if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            if (cmdkLinks.length) {
+              cmdkActive = (cmdkActive + 1) % cmdkLinks.length;
+              highlightCmdkRow(cmdkActive);
+            }
+          } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            if (cmdkLinks.length) {
+              cmdkActive = (cmdkActive - 1 + cmdkLinks.length) % cmdkLinks.length;
+              highlightCmdkRow(cmdkActive);
+            }
+          } else if (e.key === 'Enter') {
+            e.preventDefault();
+            var $a = cmdkLinks[cmdkActive];
+            if ($a) { location.href = $a.attr('href'); }
           }
         });
         $cmdk.on('click', function(e) { if (e.target === this) closeCmdK(); });
@@ -322,6 +364,7 @@
       function closeCmdK() {
         if (cmdkAbort) { cmdkAbort.abort(); cmdkAbort = null; }
         if ($cmdk) { $cmdk.remove(); $cmdk = null; }
+        cmdkLinks = [];
       }
       $('#cmdk-trigger').on('click', openCmdK);
       $(document).on('keydown', function(e) {

--- a/filenergy/templates/collections/share_landing.html
+++ b/filenergy/templates/collections/share_landing.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block title %}{{ collection.name }} · Filenergy{% endblock %}
+
+{% block content %}
+<div class="mx-auto max-w-3xl">
+  <div class="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+    Read-only shared collection. Viewed {{ link.view_count or 0 }} time{{ '' if link.view_count == 1 else 's' }}.
+    {% if link.expires_at %}
+      Link expires {{ link.expires_at.strftime('%Y-%m-%d %H:%M UTC') }}.
+    {% endif %}
+  </div>
+
+  <div class="card mt-4">
+    <h2 class="text-2xl font-semibold">{{ collection.name }}</h2>
+    {% if collection.description %}
+      <p class="mt-1 text-sm text-slate-600">{{ collection.description }}</p>
+    {% endif %}
+    <p class="mt-2 text-xs text-slate-500">
+      {{ files|length }} file{{ '' if files|length == 1 else 's' }}
+    </p>
+  </div>
+
+  <div class="card mt-4">
+    {% if files %}
+      <ul class="divide-y divide-slate-100">
+        {% for f in files %}
+          <li class="flex items-center justify-between py-2 text-sm">
+            <a class="text-brand-600 hover:underline"
+               href="/file/download/?h={{ f.url }}">{{ f.name }}</a>
+            <span class="text-xs text-slate-500">
+              {{ "%.1f"|format((f.size_bytes or 0) / 1024) }} KB · {{ f.index_status }}
+            </span>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="py-6 text-center text-sm text-slate-500">No files in this collection.</p>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/filenergy/templates/collections/view.html
+++ b/filenergy/templates/collections/view.html
@@ -7,14 +7,18 @@
     {% if collection.description %}
       <p class="mt-1 text-sm text-slate-600">{{ collection.description }}</p>
     {% endif %}
-    <div class="mt-4 flex gap-2">
+    <div class="mt-4 flex flex-wrap gap-2">
       <a class="btn btn-primary"
          href="{{ url_for('ask.index', collection=collection.slug) }}">
         Ask this collection
       </a>
+      <button id="share-collection-btn" type="button" class="btn btn-ghost">
+        <svg class="icon"><use href="#i-plug"/></svg> Share publicly
+      </button>
       <a class="btn btn-ghost"
          href="{{ url_for('collections.list_collections') }}">All collections</a>
     </div>
+    <p id="share-result" class="mt-3 hidden text-sm text-slate-500"></p>
   </div>
 
   <div class="card">
@@ -59,4 +63,20 @@
     </details>
   </div>
 </div>
+
+<script>
+$('#share-collection-btn').on('click', function() {
+  if (!confirm('Mint a public read-only link to this collection?')) return;
+  $.ajax({
+    url: '{{ url_for("collections.share", slug=collection.slug) }}',
+    method: 'POST', contentType: 'application/json', data: '{}',
+  }).done(function(resp) {
+    var $r = $('#share-result').removeClass('hidden').empty();
+    $r.append('Link: ');
+    $r.append($('<code class="rounded bg-slate-100 px-1 py-0.5 text-xs break-all"></code>').text(resp.url));
+    navigator.clipboard.writeText(resp.url).catch(function(){});
+    window.fnToast('Share link copied to clipboard', 'success');
+  }).fail(function() { window.fnToast('Could not share', 'error'); });
+});
+</script>
 {% endblock %}

--- a/filenergy/templates/file/detail.html
+++ b/filenergy/templates/file/detail.html
@@ -3,7 +3,12 @@
 {% block content %}
 <div class="mx-auto max-w-3xl space-y-6">
   <div class="card">
-    <h2 class="text-xl font-semibold">{{ file.name }}</h2>
+    <div class="flex items-start gap-2">
+      <input id="file-name-input" type="text"
+             class="min-w-0 flex-1 border-0 bg-transparent px-1 py-0 text-xl font-semibold text-slate-900 focus:bg-white focus:outline-none focus:ring-2 focus:ring-brand-500/30 focus:rounded"
+             value="{{ file.name }}">
+      <span id="file-name-status" class="mt-2 text-xs text-slate-400"></span>
+    </div>
     <p class="mt-1 text-sm text-slate-500">
       {{ "%.1f"|format((file.size_bytes or 0) / 1024) }} KB ·
       uploaded {{ file.created_at.strftime('%Y-%m-%d') if file.created_at else '' }} ·
@@ -95,4 +100,25 @@
   </div>
   {% endif %}
 </div>
+
+<script>
+$('#file-name-input').on('blur', function() {
+  var newName = $(this).val().trim();
+  if (!newName || newName === '{{ file.name|e }}') return;
+  $('#file-name-status').text('Saving…').removeClass('text-rose-600 text-emerald-600');
+  $.ajax({
+    url: '/file/{{ file.id }}/rename', method: 'POST',
+    contentType: 'application/json',
+    data: JSON.stringify({name: newName}),
+  }).done(function() {
+    $('#file-name-status').text('Saved').addClass('text-emerald-600');
+    setTimeout(function(){ $('#file-name-status').text(''); }, 1500);
+  }).fail(function() {
+    $('#file-name-status').text('Error').addClass('text-rose-600');
+  });
+}).on('keydown', function(e) {
+  if (e.key === 'Enter') { e.preventDefault(); $(this).blur(); }
+  if (e.key === 'Escape') { $(this).val('{{ file.name|e }}'); $(this).blur(); }
+});
+</script>
 {% endblock %}

--- a/filenergy/templates/file/list.html
+++ b/filenergy/templates/file/list.html
@@ -132,21 +132,55 @@ $('#bulk-clear').on('click', function() {
 $('#bulk-delete').on('click', function() {
   var ids = selectedIds();
   if (!ids.length) return;
-  if (!confirm('Delete ' + ids.length + ' file(s)? This cannot be undone.')) return;
   $.ajax({
     url: '/file/bulk_delete/', method: 'POST',
     contentType: 'application/json',
     data: JSON.stringify({ids: ids}),
-  }).done(function() {
-    ids.forEach(function(id) {
+  }).done(function(resp) {
+    var deletedIds = resp.ids || ids;
+    deletedIds.forEach(function(id) {
       $('#file-' + id).fadeOut(150, function(){ $(this).remove(); });
     });
     refreshBulkBar();
-    window.fnToast(ids.length + ' file(s) deleted', 'success');
+    showUndoToast(deletedIds);
   }).fail(function() {
     window.fnToast('Bulk delete failed', 'error');
   });
 });
+
+// Undo toast: replaces the standard auto-hide success with an actionable
+// pill. Within 8 seconds, clicking Undo POSTs /file/bulk_restore/.
+function showUndoToast(ids) {
+  var $t = $(
+    '<div class="toast toast-info animate-slide-up" role="status">' +
+      '<svg class="icon-lg mt-0.5"><use href="#i-trash"/></svg>' +
+      '<div class="flex-1">' + ids.length + ' file(s) deleted</div>' +
+      '<button class="undo-btn rounded bg-white px-2 py-0.5 text-xs font-medium text-brand-600 hover:bg-slate-100">Undo</button>' +
+      '<button class="toast-close text-slate-400 hover:text-slate-700">' +
+        '<svg class="icon"><use href="#i-x"/></svg>' +
+      '</button>' +
+    '</div>'
+  );
+  $('#toast-container').append($t);
+  var hideTimer = setTimeout(function() {
+    $t.fadeOut(200, function(){ $(this).remove(); });
+  }, 8000);
+  $t.find('.undo-btn').on('click', function() {
+    clearTimeout(hideTimer);
+    $.ajax({
+      url: '/file/bulk_restore/', method: 'POST',
+      contentType: 'application/json',
+      data: JSON.stringify({ids: ids}),
+    }).done(function() {
+      $t.fadeOut(150, function(){ $(this).remove(); });
+      window.fnToast(ids.length + ' file(s) restored', 'success');
+      // Reload so the table picks up the restored rows.
+      setTimeout(function(){ location.reload(); }, 400);
+    }).fail(function() {
+      window.fnToast('Could not restore', 'error');
+    });
+  });
+}
 
 $('#bulk-reindex').on('click', function() {
   var ids = selectedIds();
@@ -160,11 +194,11 @@ $('#bulk-reindex').on('click', function() {
 });
 
 function deleteFile(id) {
-  if (!confirm("Delete this file?")) return;
   var $row = $("#file-" + id);
   $row.css('opacity', 0.4);
   $.post("/file/delete/", {id: id}).done(function() {
     $row.fadeOut(150, function(){ $(this).remove(); });
+    showUndoToast([id]);
   }).fail(function() {
     $row.css('opacity', 1);
     window.fnToast('Could not delete file', 'error');

--- a/filenergy/templates/index/index.html
+++ b/filenergy/templates/index/index.html
@@ -1,71 +1,296 @@
 {% extends "base.html" %}
 
-{% block title %}Filenergy — your files, but askable{% endblock %}
+{% block title %}Filenergy — chat with your team's files{% endblock %}
 
 {% block content %}
-<section class="py-16 text-center">
-  <h1 class="mx-auto max-w-3xl text-4xl font-bold tracking-tight text-slate-900 sm:text-5xl">
-    Your files, but <span class="text-brand-500">askable</span>.
-  </h1>
-  <p class="mx-auto mt-4 max-w-2xl text-lg leading-7 text-slate-600">
-    A private file host that indexes every PDF, doc, and note you upload —
-    then lets you chat with them. Powered by Claude, self-hostable in a
-    container.
-  </p>
-  <div class="mt-8 flex justify-center gap-3">
-    {% if g.user.is_authenticated %}
-      <a class="btn btn-primary btn-large" href="/file/upload/">Upload a file</a>
-      <a class="btn btn-large" href="/ask/">Ask your library</a>
-    {% else %}
-      <a class="btn btn-primary btn-large" href="/user/register/">Get started — free</a>
-      <a class="btn btn-large" href="/user/login/">Sign in</a>
-    {% endif %}
+
+{# ---------- Hero ---------- #}
+<section class="relative overflow-hidden py-16 sm:py-24">
+  <div class="absolute inset-0 -z-10 bg-gradient-to-b from-brand-50/60 via-white to-white"></div>
+  <div class="absolute inset-x-0 top-0 -z-10 mx-auto h-72 max-w-3xl rounded-full bg-brand-100/60 blur-3xl"></div>
+
+  <div class="mx-auto max-w-3xl text-center">
+    <span class="pill pill-brand mb-5">
+      <svg class="icon mr-1"><use href="#i-chat"/></svg>
+      AI knowledge base · self-hostable · Claude-powered
+    </span>
+    <h1 class="text-4xl font-bold tracking-tight text-slate-900 sm:text-6xl">
+      Your team's files,<br>
+      <span class="bg-gradient-to-r from-brand-500 to-brand-700 bg-clip-text text-transparent">
+        finally askable.
+      </span>
+    </h1>
+    <p class="mx-auto mt-5 max-w-2xl text-lg leading-7 text-slate-600">
+      Drop in PDFs, contracts, meeting notes, Slack threads, Drive files.
+      Filenergy extracts, embeds, and lets your whole team chat with the
+      library — with citations that point straight back to the source.
+    </p>
+    <div class="mt-8 flex flex-wrap justify-center gap-3">
+      {% if g.user.is_authenticated %}
+        <a class="btn btn-primary btn-large" href="/ask/">
+          <svg class="icon"><use href="#i-chat"/></svg> Open chat
+        </a>
+        <a class="btn btn-large" href="/file/upload/">Upload a file</a>
+      {% else %}
+        <a class="btn btn-primary btn-large" href="/user/register/">
+          Get started — free
+        </a>
+        <a class="btn btn-large" href="#how">See how it works</a>
+      {% endif %}
+    </div>
+    <p class="mt-4 text-xs text-slate-500">
+      Free for individuals · self-host on your own server · no credit card
+    </p>
+  </div>
+
+  {# Visual mockup of the chat. #}
+  <div class="mx-auto mt-14 max-w-4xl px-4">
+    <div class="rounded-2xl bg-white p-2 shadow-2xl ring-1 ring-slate-200">
+      <img src="/static/img/landing-chat.svg"
+           alt="Filenergy chat with citations"
+           class="w-full rounded-xl">
+    </div>
   </div>
 </section>
 
-<section class="grid gap-4 py-8 sm:grid-cols-2 lg:grid-cols-3">
-  {% set features = [
-    ("Drop in any document",  "PDF, DOCX, Markdown, TXT, CSV, HTML — text extracted on the way in."),
-    ("Semantic search",       "Voyage embeddings. Ask in plain language; relevant excerpts surface in milliseconds."),
-    ("Cited answers",         "Claude grounds every answer in your files. Sources link back to the source paragraph."),
-    ("Streaming responses",   "Real-time tokens via Server-Sent Events. No 10-second blocking calls."),
-    ("Multi-turn memory",     "Threads persist; pick up where you left off."),
-    ("Private by default",    "Per-workspace isolation, hash-based share URLs, public toggle per file."),
-    ("Connectors",            "Google Drive, Notion, Slack, Dropbox — incremental sync via cursors."),
-    ("Webhooks + REST API",   "HMAC-signed outbound webhooks, OpenAPI-documented /api/v1 with per-key scopes."),
-    ("Self-hostable",         "Docker + Postgres + optional pgvector. SAML SSO + 2FA + audit log built in."),
-  ] %}
-  {% for title, body in features %}
-    <div class="card">
-      <h3 class="card-title">{{ title }}</h3>
-      <p class="mt-2 text-sm text-slate-600">{{ body }}</p>
+{# ---------- Logos / proof strip ---------- #}
+<section class="border-y border-slate-200 bg-white py-8">
+  <div class="mx-auto max-w-5xl px-4">
+    <p class="text-center text-xs font-semibold uppercase tracking-wider text-slate-500">
+      Built on the same stack the AI labs ship
+    </p>
+    <div class="mt-4 flex flex-wrap items-center justify-center gap-x-10 gap-y-3 text-slate-400">
+      <span class="text-sm font-semibold">Anthropic Claude</span>
+      <span class="text-sm font-semibold">Voyage AI</span>
+      <span class="text-sm font-semibold">pgvector</span>
+      <span class="text-sm font-semibold">Flask</span>
+      <span class="text-sm font-semibold">Stripe</span>
+      <span class="text-sm font-semibold">SAML 2.0</span>
+      <span class="text-sm font-semibold">WebAuthn</span>
     </div>
-  {% endfor %}
+  </div>
 </section>
 
-<section class="card my-8 bg-slate-900 text-slate-100">
-  <h3 class="card-title text-white">How it works</h3>
-  <pre class="mt-3 whitespace-pre-wrap font-mono text-xs leading-5 text-slate-300">upload  →  text extraction  →  chunk &amp; embed (Voyage)  →  SQLite / Postgres + pgvector
-
-ask     →  embed query  →  cosine top-K  →  Claude (RAG, streaming)  →  cited answer</pre>
+{# ---------- Three-up value prop ---------- #}
+<section class="py-16 sm:py-24">
+  <div class="mx-auto max-w-5xl px-4">
+    <div class="grid gap-8 md:grid-cols-3">
+      <div>
+        <div class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-brand-100 text-brand-600">
+          <svg class="icon-lg"><use href="#i-search"/></svg>
+        </div>
+        <h3 class="mt-3 text-lg font-semibold">Cited answers, not guesses</h3>
+        <p class="mt-2 text-sm text-slate-600">
+          Every answer is grounded in retrieved chunks of your real files.
+          One-click drill-through to the source paragraph.
+        </p>
+      </div>
+      <div>
+        <div class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-brand-100 text-brand-600">
+          <svg class="icon-lg"><use href="#i-plug"/></svg>
+        </div>
+        <h3 class="mt-3 text-lg font-semibold">Connect what you already use</h3>
+        <p class="mt-2 text-sm text-slate-600">
+          Google Drive · Notion · Slack · Dropbox. Incremental sync,
+          per-workspace OAuth, no third-party indexer.
+        </p>
+      </div>
+      <div>
+        <div class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-brand-100 text-brand-600">
+          <svg class="icon-lg"><use href="#i-cog"/></svg>
+        </div>
+        <h3 class="mt-3 text-lg font-semibold">Enterprise-grade, day one</h3>
+        <p class="mt-2 text-sm text-slate-600">
+          SAML SSO, SCIM, 2FA + WebAuthn, encryption at rest, audit log,
+          GDPR exports — already in the box.
+        </p>
+      </div>
+    </div>
+  </div>
 </section>
 
-<section class="card my-8">
-  <h4 class="card-title">Search files by name</h4>
-  <form class="mt-3 flex gap-2" onsubmit="searchFiles(this); return false;">
-    <input class="input flex-1" type="text" name="name" placeholder="invoice, brief, meeting notes…">
-    <button class="btn btn-primary" type="submit">Search</button>
-  </form>
-  <div id="results" class="mt-4 text-sm"></div>
+{# ---------- How it works ---------- #}
+<section id="how" class="py-16 sm:py-20">
+  <div class="mx-auto max-w-5xl px-4">
+    <h2 class="text-center text-3xl font-bold tracking-tight text-slate-900">
+      How it works
+    </h2>
+    <p class="mx-auto mt-3 max-w-xl text-center text-slate-600">
+      No vendor lock-in. No cloud-only. The whole stack runs in one container.
+    </p>
+
+    <div class="mt-10 grid gap-6 md:grid-cols-4">
+      {% for step in [
+        ('1', 'Upload', 'Drop files, paste a URL, or connect a source. We OCR, transcribe, and chunk.'),
+        ('2', 'Embed', 'Voyage embeddings into SQLite or pgvector. Encrypted at rest with your KEK.'),
+        ('3', 'Ask', 'Type, paste an image, or pick a starter. Streaming answers via SSE.'),
+        ('4', 'Cite', 'Every assistant turn links back to the chunk it used. Click → source paragraph.'),
+      ] %}
+        <div class="card text-center">
+          <span class="mx-auto flex h-9 w-9 items-center justify-center rounded-full bg-brand-500 text-sm font-semibold text-white">{{ step[0] }}</span>
+          <h3 class="mt-3 font-semibold">{{ step[1] }}</h3>
+          <p class="mt-2 text-sm text-slate-600">{{ step[2] }}</p>
+        </div>
+      {% endfor %}
+    </div>
+  </div>
 </section>
 
-<script>
-  function searchFiles(form) {
-    var data = new FormData(form);
-    $.post("/file/search/", new URLSearchParams(data).toString(), function(html) {
-      $("#results").html(html);
-    });
-  }
-  function downloadFile(h) { location.href = "/file/download/?h=" + h; }
-</script>
+{# ---------- Feature grid ---------- #}
+<section class="bg-slate-50 py-16 sm:py-20">
+  <div class="mx-auto max-w-6xl px-4">
+    <h2 class="text-center text-3xl font-bold tracking-tight text-slate-900">
+      Everything you need, none of the bloat
+    </h2>
+
+    <div class="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {% for icon, title, body in [
+        ('i-chat', 'Streaming chat', 'Server-Sent Events feed tokens to the browser as Claude generates them. Stop, regenerate, copy, thumbs up/down.'),
+        ('i-files', 'Vision in chat', 'Paste a screenshot into the composer and ask "where is this in our docs?". Claude sees both.'),
+        ('i-folder', 'Collections', 'Group files into notebooks. Scope a chat to one notebook, one file, or your whole library.'),
+        ('i-plug', 'Connectors', 'Drive, Notion, Slack, Dropbox. Incremental sync via cursors — no full re-scan, no quota waste.'),
+        ('i-search', 'Command palette', '⌘K from anywhere. Search files, conversations, collections, jump to any setting.'),
+        ('i-chart', 'Evals dashboard', 'Per-message thumbs up/down feeds an answer-quality dashboard. Find regressions before customers do.'),
+        ('i-cog', 'SAML SSO + SCIM', 'Okta, Workspace, Auth0, Azure AD. Auto-provision users + groups via SCIM 2.0.'),
+        ('i-alert', 'Audit + webhooks', 'Every action lands in the Event log. Customers get HMAC-signed POSTs on the events they pick.'),
+        ('i-refresh', 'Self-hostable', 'One container, SQLite or Postgres + pgvector. Ship Filenergy on your own infra in 5 minutes.'),
+      ] %}
+        <div class="card">
+          <div class="flex items-center gap-2">
+            <div class="inline-flex h-8 w-8 items-center justify-center rounded-md bg-brand-100 text-brand-600">
+              <svg class="icon"><use href="#{{ icon }}"/></svg>
+            </div>
+            <h3 class="font-semibold">{{ title }}</h3>
+          </div>
+          <p class="mt-2 text-sm text-slate-600">{{ body }}</p>
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+
+{# ---------- Big code block / API tease ---------- #}
+<section class="py-16 sm:py-20">
+  <div class="mx-auto grid max-w-5xl gap-10 px-4 lg:grid-cols-2">
+    <div>
+      <h2 class="text-3xl font-bold tracking-tight text-slate-900">
+        Programmable from day one
+      </h2>
+      <p class="mt-3 text-slate-600">
+        Bearer-token API with per-key scopes. OpenAPI 3 spec at
+        <code class="rounded bg-slate-100 px-1 text-sm">/api/v1/openapi.json</code>,
+        Swagger UI at <code class="rounded bg-slate-100 px-1 text-sm">/api/v1/docs</code>.
+      </p>
+      <ul class="mt-4 space-y-2 text-sm text-slate-600">
+        <li class="flex gap-2">
+          <svg class="icon mt-0.5 text-brand-500"><use href="#i-check"/></svg>
+          Workspace-scoped tokens; rotate any time
+        </li>
+        <li class="flex gap-2">
+          <svg class="icon mt-0.5 text-brand-500"><use href="#i-check"/></svg>
+          Granular scopes (files:read, ask:write, …)
+        </li>
+        <li class="flex gap-2">
+          <svg class="icon mt-0.5 text-brand-500"><use href="#i-check"/></svg>
+          Outbound webhooks with HMAC-SHA256 signatures
+        </li>
+        <li class="flex gap-2">
+          <svg class="icon mt-0.5 text-brand-500"><use href="#i-check"/></svg>
+          Email-to-ingest: forward a mail, get a file
+        </li>
+      </ul>
+    </div>
+    <pre class="overflow-auto rounded-xl bg-slate-900 p-5 text-xs leading-relaxed text-slate-100 shadow-2xl">
+<span class="text-slate-400"># Ask via REST</span>
+curl -X POST https://your-host/api/v1/ask \
+  -H "Authorization: Bearer $FILENERGY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d <span class="text-emerald-300">'{"question": "What does the Acme MSA say about termination?"}'</span>
+
+<span class="text-slate-400"># Drop a file</span>
+curl -X POST https://your-host/api/v1/files \
+  -H "Authorization: Bearer $FILENERGY_TOKEN" \
+  -F "files[]=@./contract.pdf"</pre>
+  </div>
+</section>
+
+{# ---------- Pricing tease ---------- #}
+<section class="bg-slate-50 py-16 sm:py-20">
+  <div class="mx-auto max-w-5xl px-4">
+    <h2 class="text-center text-3xl font-bold tracking-tight text-slate-900">
+      Simple pricing
+    </h2>
+    <p class="mx-auto mt-3 max-w-xl text-center text-slate-600">
+      Start free. Upgrade when your team needs more.
+    </p>
+
+    <div class="mt-10 grid gap-4 md:grid-cols-3">
+      <div class="card">
+        <div class="text-sm font-semibold uppercase tracking-wide text-slate-500">Free</div>
+        <div class="mt-2 text-3xl font-bold">$0</div>
+        <p class="text-sm text-slate-500">Forever, for individuals.</p>
+        <ul class="mt-4 space-y-2 text-sm">
+          <li class="flex gap-2"><svg class="icon mt-0.5 text-emerald-500"><use href="#i-check"/></svg>Up to 100 files</li>
+          <li class="flex gap-2"><svg class="icon mt-0.5 text-emerald-500"><use href="#i-check"/></svg>500 questions/month</li>
+          <li class="flex gap-2"><svg class="icon mt-0.5 text-emerald-500"><use href="#i-check"/></svg>1 GB storage</li>
+        </ul>
+        <a class="btn btn-ghost mt-5 w-full" href="/user/register/">Start free</a>
+      </div>
+
+      <div class="card border-2 border-brand-500 shadow-lg">
+        <div class="flex items-center justify-between">
+          <div class="text-sm font-semibold uppercase tracking-wide text-brand-600">Pro</div>
+          <span class="pill pill-brand">Most popular</span>
+        </div>
+        <div class="mt-2 text-3xl font-bold">$19<span class="text-base font-normal text-slate-500">/mo</span></div>
+        <p class="text-sm text-slate-500">For prosumers and small teams.</p>
+        <ul class="mt-4 space-y-2 text-sm">
+          <li class="flex gap-2"><svg class="icon mt-0.5 text-emerald-500"><use href="#i-check"/></svg>5,000 files</li>
+          <li class="flex gap-2"><svg class="icon mt-0.5 text-emerald-500"><use href="#i-check"/></svg>10,000 questions/month</li>
+          <li class="flex gap-2"><svg class="icon mt-0.5 text-emerald-500"><use href="#i-check"/></svg>50 GB storage</li>
+          <li class="flex gap-2"><svg class="icon mt-0.5 text-emerald-500"><use href="#i-check"/></svg>Connectors + webhooks</li>
+        </ul>
+        <a class="btn btn-primary mt-5 w-full" href="/user/register/?plan=pro">Start Pro trial</a>
+      </div>
+
+      <div class="card">
+        <div class="text-sm font-semibold uppercase tracking-wide text-slate-500">Team</div>
+        <div class="mt-2 text-3xl font-bold">$99<span class="text-base font-normal text-slate-500">/mo</span></div>
+        <p class="text-sm text-slate-500">For organisations &amp; compliance.</p>
+        <ul class="mt-4 space-y-2 text-sm">
+          <li class="flex gap-2"><svg class="icon mt-0.5 text-emerald-500"><use href="#i-check"/></svg>Unlimited files &amp; storage</li>
+          <li class="flex gap-2"><svg class="icon mt-0.5 text-emerald-500"><use href="#i-check"/></svg>SAML SSO + SCIM</li>
+          <li class="flex gap-2"><svg class="icon mt-0.5 text-emerald-500"><use href="#i-check"/></svg>Workspace 2FA enforcement</li>
+          <li class="flex gap-2"><svg class="icon mt-0.5 text-emerald-500"><use href="#i-check"/></svg>Priority support</li>
+        </ul>
+        <a class="btn btn-ghost mt-5 w-full" href="/user/register/?plan=team">Talk to sales</a>
+      </div>
+    </div>
+
+    <p class="mt-6 text-center text-xs text-slate-500">
+      Self-hosting? <a class="text-brand-600 hover:underline" href="https://github.com">Run it on your own server</a> for free.
+    </p>
+  </div>
+</section>
+
+{# ---------- Final CTA ---------- #}
+<section class="py-16 sm:py-24">
+  <div class="mx-auto max-w-3xl rounded-2xl bg-gradient-to-r from-brand-600 to-brand-700 px-8 py-12 text-center text-white shadow-2xl">
+    <h2 class="text-3xl font-bold tracking-tight">
+      Stop searching. Start asking.
+    </h2>
+    <p class="mt-3 text-brand-100">
+      Set up takes 5 minutes. The first answer comes back in seconds.
+    </p>
+    <div class="mt-6 flex flex-wrap justify-center gap-3">
+      <a class="btn btn-large bg-white text-brand-700 hover:bg-slate-100" href="/user/register/">
+        Get started — free
+      </a>
+      <a class="btn btn-large border-white/30 bg-transparent text-white hover:bg-white/10" href="#how">
+        Read the docs
+      </a>
+    </div>
+  </div>
+</section>
+
 {% endblock %}

--- a/filenergy/templates/settings/workspace.html
+++ b/filenergy/templates/settings/workspace.html
@@ -153,6 +153,30 @@
 </section>
 
 <section class="card">
+  <h3 class="card-title">Email-to-ingest</h3>
+  {% if inbound_address %}
+    <p class="mt-1 text-sm text-slate-600">
+      Forward an email to this address and it will be parsed, ingested,
+      and indexed into this workspace. Attachments become files. Body
+      becomes a markdown note.
+    </p>
+    <div class="mt-3 flex items-center gap-2 rounded bg-slate-100 px-3 py-2 font-mono text-sm">
+      <span class="flex-1 break-all">{{ inbound_address }}</span>
+      <button type="button" class="btn btn-ghost text-xs"
+              onclick="navigator.clipboard.writeText('{{ inbound_address }}').then(function(){ window.fnToast('Copied','success'); })">
+        Copy
+      </button>
+    </div>
+  {% else %}
+    <p class="mt-1 text-sm text-slate-500">
+      Inbound email is not configured on this instance. The administrator
+      can enable it by setting <code class="rounded bg-slate-100 px-1">FILENERGY_INBOUND_DOMAIN</code>
+      and <code class="rounded bg-slate-100 px-1">FILENERGY_INBOUND_SECRET</code>.
+    </p>
+  {% endif %}
+</section>
+
+<section class="card">
   <h3 class="card-title">Export workspace data</h3>
   <p class="text-sm text-slate-600">
     Download a ZIP bundle with files, conversations, audit log and member

--- a/filenergy/views/__init__.py
+++ b/filenergy/views/__init__.py
@@ -12,9 +12,11 @@ from filenergy.views.dashboard import dashboard_bp
 from filenergy.views.docs import docs_bp
 from filenergy.views.file import file_bp
 from filenergy.views.health import health_bp
+from filenergy.views.inbound import inbound_bp
 from filenergy.views.index import index_bp
 from filenergy.views.onboarding import onboarding_bp
 from filenergy.views.saml import saml_bp
+from filenergy.views.scim import scim_bp
 from filenergy.views.settings_views import settings_bp
 from filenergy.views.share import share_bp
 from filenergy.views.user import user_bp
@@ -37,6 +39,8 @@ app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
 app.register_blueprint(connectors_bp, url_prefix="/connectors")
 app.register_blueprint(conversation_share_bp, url_prefix="/sc")
 app.register_blueprint(saml_bp, url_prefix="/saml")
+app.register_blueprint(scim_bp, url_prefix="/scim")
+app.register_blueprint(inbound_bp, url_prefix="/inbound")
 app.register_blueprint(health_bp)
 
 # API keys + Stripe webhook authenticate themselves (Bearer / HMAC); they
@@ -46,6 +50,10 @@ csrf.exempt(billing_bp)
 # SAML ACS receives a SAMLResponse from the IdP, not a browser form, so
 # there's no CSRF token available.
 csrf.exempt(saml_bp)
+# Inbound email webhook is signed by the provider, not the browser.
+csrf.exempt(inbound_bp)
+# SCIM uses bearer-token auth; IdPs don't carry CSRF tokens.
+csrf.exempt(scim_bp)
 
 
 @app.errorhandler(404)

--- a/filenergy/views/ask.py
+++ b/filenergy/views/ask.py
@@ -396,6 +396,42 @@ def rename_conversation(conversation_id):
     return jsonify(ok=True, title=conv.title)
 
 
+@ask_bp.route("/c/<int:conversation_id>/pin", methods=["POST"])
+@login_required
+def pin_conversation(conversation_id):
+    """Toggle pin state. Pinned conversations float to the top of the
+    sidebar so users keep their long-running threads at hand."""
+    from filenergy import db
+    from filenergy.models import Conversation, utcnow
+
+    conv = Conversation.query.filter_by(
+        id=conversation_id, user_id=g.user.id, workspace_id=g.workspace.id,
+    ).first()
+    if conv is None:
+        return jsonify(error="Not found"), 404
+    conv.pinned_at = None if conv.pinned_at else utcnow()
+    db.session.commit()
+    return jsonify(ok=True, pinned=conv.pinned_at is not None)
+
+
+@ask_bp.route("/c/<int:conversation_id>/archive", methods=["POST"])
+@login_required
+def archive_conversation(conversation_id):
+    """Toggle archive state. Archived threads are hidden from the
+    sidebar but kept in the DB for export + audit."""
+    from filenergy import db
+    from filenergy.models import Conversation, utcnow
+
+    conv = Conversation.query.filter_by(
+        id=conversation_id, user_id=g.user.id, workspace_id=g.workspace.id,
+    ).first()
+    if conv is None:
+        return jsonify(error="Not found"), 404
+    conv.archived_at = None if conv.archived_at else utcnow()
+    db.session.commit()
+    return jsonify(ok=True, archived=conv.archived_at is not None)
+
+
 @ask_bp.route("/feedback", methods=["POST"])
 @login_required
 def feedback():

--- a/filenergy/views/collections.py
+++ b/filenergy/views/collections.py
@@ -80,3 +80,57 @@ def assign():
             return jsonify(error="Collection not found"), 404
     collections.assign_file(f, coll)
     return jsonify(ok=True, collection_id=coll.id if coll else None)
+
+
+@collections_bp.route("/<slug>/share", methods=["POST"])
+@login_required
+def share(slug):
+    """Mint a public read-only link to the entire collection."""
+    import secrets
+    from datetime import timedelta
+    from filenergy import db
+    from filenergy.models import CollectionShareLink, utcnow
+
+    coll = collections.get_by_slug(g.workspace, slug)
+    if coll is None:
+        abort(404)
+    payload = request.get_json(silent=True) or request.form
+    ttl_raw = payload.get("ttl_hours") if payload else None
+    try:
+        ttl = int(ttl_raw) if ttl_raw else None
+    except (TypeError, ValueError):
+        ttl = None
+    link = CollectionShareLink(
+        collection_id=coll.id,
+        token=secrets.token_urlsafe(24),
+        created_by_id=g.user.id,
+        expires_at=(utcnow() + timedelta(hours=ttl)) if ttl else None,
+    )
+    db.session.add(link); db.session.commit()
+    return jsonify(
+        ok=True, token=link.token,
+        url=url_for("collections.share_landing", token=link.token, _external=True),
+    )
+
+
+@collections_bp.route("/share/<token>")
+def share_landing(token):
+    """Public read-only listing of a shared collection. No auth needed."""
+    from filenergy import db
+    from filenergy.models import CollectionShareLink, File
+
+    link = CollectionShareLink.query.filter_by(token=token).first()
+    if link is None or not link.is_active():
+        abort(404)
+    link.view_count = (link.view_count or 0) + 1
+    db.session.commit()
+    files = (
+        File.query.filter(
+            File.collection_id == link.collection_id,
+            File.deleted_at.is_(None),
+        ).order_by(File.id.desc()).all()
+    )
+    return render_template(
+        "collections/share_landing.html",
+        link=link, collection=link.collection, files=files,
+    )

--- a/filenergy/views/file.py
+++ b/filenergy/views/file.py
@@ -105,6 +105,7 @@ def chunk_context(chunk_id):
 def list_files():
     files = (
         File.query.filter_by(workspace_id=g.workspace.id)
+        .filter(File.deleted_at.is_(None))
         .order_by(File.id.desc())
         .all()
     )
@@ -190,18 +191,34 @@ def search():
 @file_bp.route("/delete/", methods=["POST"])
 @login_required
 def delete():
+    """Soft-delete a single file (same grace window as bulk_delete)."""
+    from filenergy import db
+    from filenergy.models import utcnow
+
     db_file = File.query.filter_by(
-        id=request.form.get("id"), workspace_id=g.workspace.id
-    ).first()
-    if not FileService().delete(db_file):
-        return "fail"
-    return "ok"
+        id=request.form.get("id"), workspace_id=g.workspace.id,
+    ).filter(File.deleted_at.is_(None)).first()
+    if db_file is None:
+        return jsonify(error="Not found"), 404
+    db_file.deleted_at = utcnow()
+    db.session.commit()
+    events.log_event(
+        events.FILE_DELETED,
+        user=g.user, workspace_id=g.workspace.id, file_id=db_file.id, soft=True,
+    )
+    return jsonify(ok=True, id=db_file.id)
 
 
 @file_bp.route("/bulk_delete/", methods=["POST"])
 @login_required
 def bulk_delete():
-    # Accept both form-encoded (legacy) and JSON (UI multi-select).
+    """Soft-delete selected files. Files are hidden from the UI but stay
+    in the DB for `FILENERGY_DELETE_GRACE_HOURS` (default 24h) so users
+    can Undo from the toast. A periodic `flask purge-deleted-files` job
+    hard-deletes after the grace window.
+    """
+    from filenergy.models import utcnow
+
     raw_ids = request.form.getlist("ids[]") or request.form.getlist("ids")
     if not raw_ids:
         body = request.get_json(silent=True) or {}
@@ -213,17 +230,76 @@ def bulk_delete():
         except (TypeError, ValueError):
             pass
     if not ids:
-        return jsonify(deleted=0)
+        return jsonify(deleted=0, ids=[])
+
+    from filenergy import db
+    files = File.query.filter(
+        File.id.in_(ids),
+        File.workspace_id == g.workspace.id,
+        File.deleted_at.is_(None),
+    ).all()
+    soft_deleted_ids: list[int] = []
+    now = utcnow()
+    for f in files:
+        f.deleted_at = now
+        soft_deleted_ids.append(f.id)
+    db.session.commit()
+    for fid in soft_deleted_ids:
+        events.log_event(
+            events.FILE_DELETED,
+            user=g.user, workspace_id=g.workspace.id, file_id=fid, soft=True,
+        )
+    return jsonify(deleted=len(soft_deleted_ids), ids=soft_deleted_ids)
+
+
+@file_bp.route("/bulk_restore/", methods=["POST"])
+@login_required
+def bulk_restore():
+    """Reverse a soft-delete within the grace window."""
+    from filenergy import db
+
+    body = request.get_json(silent=True) or {}
+    raw_ids = body.get("ids") or []
+    ids: list[int] = []
+    for x in raw_ids:
+        try:
+            ids.append(int(x))
+        except (TypeError, ValueError):
+            pass
+    if not ids:
+        return jsonify(restored=0)
 
     files = File.query.filter(
-        File.id.in_(ids), File.workspace_id == g.workspace.id,
+        File.id.in_(ids),
+        File.workspace_id == g.workspace.id,
+        File.deleted_at.isnot(None),
     ).all()
-    deleted = 0
-    svc = FileService()
+    restored = 0
     for f in files:
-        if svc.delete(f):
-            deleted += 1
-    return jsonify(deleted=deleted)
+        f.deleted_at = None
+        restored += 1
+    db.session.commit()
+    return jsonify(restored=restored)
+
+
+@file_bp.route("/<int:file_id>/rename", methods=["POST"])
+@login_required
+def rename(file_id):
+    """Rename a file in place. Used by the file detail view."""
+    from filenergy import db
+
+    f = File.query.filter_by(
+        id=file_id, workspace_id=g.workspace.id,
+    ).first()
+    if f is None:
+        return jsonify(error="Not found"), 404
+    body = request.get_json(silent=True) or {}
+    name = (body.get("name") or "").strip()
+    if not name:
+        return jsonify(error="Name is required"), 400
+    f.name = name[:1000]
+    db.session.commit()
+    return jsonify(ok=True, name=f.name)
 
 
 @file_bp.route("/reindex/", methods=["POST"])

--- a/filenergy/views/inbound.py
+++ b/filenergy/views/inbound.py
@@ -1,0 +1,51 @@
+"""Inbound email webhook.
+
+Receives JSON POSTs from inbound-mail providers (Postmark, SendGrid,
+Mailgun, Cloudflare Email Workers). The endpoint is CSRF-exempt and
+authenticates by:
+
+  - matching the To address to a per-workspace deterministic local-part
+    derived from a shared secret, AND
+  - optionally a `X-Inbound-Secret` header that providers can sign with.
+
+The endpoint is a noop unless `FILENERGY_INBOUND_DOMAIN` and
+`FILENERGY_INBOUND_SECRET` are both set.
+"""
+from __future__ import annotations
+
+import hmac
+import os
+
+from flask import Blueprint, jsonify, request
+
+from filenergy.services import inbound_email
+
+inbound_bp = Blueprint("inbound", __name__)
+
+
+def _check_provider_secret() -> bool:
+    """Optional shared-secret header — providers like Postmark let you
+    set a static string. Skip when not configured."""
+    expected = os.environ.get("FILENERGY_INBOUND_SHARED_SECRET")
+    if not expected:
+        return True
+    presented = request.headers.get("X-Inbound-Secret", "")
+    return hmac.compare_digest(expected, presented)
+
+
+@inbound_bp.route("/email", methods=["POST"])
+def email():
+    if not inbound_email.is_configured():
+        return jsonify(error="inbound disabled"), 503
+    if not _check_provider_secret():
+        return jsonify(error="unauthorized"), 401
+
+    payload = request.get_json(silent=True) or {}
+    if not isinstance(payload, dict):
+        return jsonify(error="bad payload"), 400
+    result = inbound_email.ingest_payload(payload)
+    if not result.get("ok"):
+        # Return 200 anyway so providers don't keep retrying a bad
+        # address; log internally instead.
+        return jsonify(result), 200
+    return jsonify(result), 200

--- a/filenergy/views/scim.py
+++ b/filenergy/views/scim.py
@@ -1,0 +1,312 @@
+"""SCIM 2.0 — auto-provisioning from Okta, Workspace, Auth0, Azure AD.
+
+Implements the slice of RFC 7644 that identity providers actually use:
+
+  GET    /scim/v2/Users
+  GET    /scim/v2/Users/<id>
+  POST   /scim/v2/Users
+  PUT    /scim/v2/Users/<id>
+  PATCH  /scim/v2/Users/<id>
+  DELETE /scim/v2/Users/<id>
+  GET    /scim/v2/ServiceProviderConfig
+  GET    /scim/v2/Schemas
+  GET    /scim/v2/ResourceTypes
+
+Auth: bearer token in `Authorization: Bearer <token>`, compared
+constant-time against `FILENERGY_SCIM_TOKEN`. The endpoint is
+workspace-scoped via a second header `X-Filenergy-Workspace-Slug`
+(IdPs let you set arbitrary headers on the SCIM connection).
+
+Provisioning a SCIM user creates (or revives) a `User` row + a
+`WorkspaceMember` link. De-provisioning removes the membership but
+preserves the User and audit trail. This matches what compliant SaaS
+products do — disabling a user shouldn't nuke their data.
+"""
+from __future__ import annotations
+
+import hmac
+import json
+import logging
+import os
+import secrets
+from typing import Any
+
+from flask import Blueprint, jsonify, request
+
+from filenergy import db
+from filenergy.models import User, Workspace, WorkspaceMember, utcnow
+
+scim_bp = Blueprint("scim", __name__)
+
+log = logging.getLogger(__name__)
+
+
+SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User"
+SCIM_LIST_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+SCIM_ERROR_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:Error"
+SCIM_PATCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+
+
+def _scim_error(detail: str, status: int) -> tuple:
+    return jsonify({
+        "schemas": [SCIM_ERROR_SCHEMA],
+        "detail": detail,
+        "status": str(status),
+    }), status
+
+
+def _check_auth(workspace_slug: str | None = None) -> tuple[Workspace | None, tuple | None]:
+    """Returns (workspace, error_response). On success the second slot is None."""
+    expected = os.environ.get("FILENERGY_SCIM_TOKEN")
+    if not expected:
+        return None, _scim_error("SCIM disabled — set FILENERGY_SCIM_TOKEN", 503)
+
+    auth = request.headers.get("Authorization", "")
+    if not auth.lower().startswith("bearer "):
+        return None, _scim_error("Missing bearer token", 401)
+    presented = auth.split(" ", 1)[1].strip()
+    if not hmac.compare_digest(expected, presented):
+        return None, _scim_error("Invalid bearer token", 401)
+
+    slug = workspace_slug or request.headers.get("X-Filenergy-Workspace-Slug", "")
+    if not slug:
+        return None, _scim_error("Missing X-Filenergy-Workspace-Slug header", 400)
+    ws = Workspace.query.filter_by(slug=slug).first()
+    if ws is None:
+        return None, _scim_error(f"Workspace '{slug}' not found", 404)
+    return ws, None
+
+
+def _user_to_scim(user: User, workspace: Workspace, *, role: str = "member") -> dict[str, Any]:
+    return {
+        "schemas": [SCIM_USER_SCHEMA],
+        "id": str(user.id),
+        "userName": user.email or user.username or str(user.id),
+        "name": {"formatted": user.username or user.email or ""},
+        "emails": [{"value": user.email or "", "primary": True}],
+        "active": True,
+        "meta": {
+            "resourceType": "User",
+            "created": user.created_at.isoformat() if user.created_at else None,
+            "location": f"/scim/v2/Users/{user.id}",
+        },
+        # Custom attribute: which role the user has in the workspace.
+        "urn:ietf:params:scim:schemas:extension:filenergy:2.0:User": {
+            "workspaceRole": role,
+            "workspaceSlug": workspace.slug,
+        },
+    }
+
+
+def _existing_membership(workspace: Workspace, user: User) -> WorkspaceMember | None:
+    return WorkspaceMember.query.filter_by(
+        workspace_id=workspace.id, user_id=user.id,
+    ).first()
+
+
+# ---------------------------------------------------------------------------
+# Discovery endpoints — Okta / Workspace probe these on connection setup.
+# ---------------------------------------------------------------------------
+
+
+@scim_bp.route("/v2/ServiceProviderConfig")
+def service_provider_config():
+    return jsonify({
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
+        "patch": {"supported": True},
+        "bulk": {"supported": False, "maxOperations": 0, "maxPayloadSize": 0},
+        "filter": {"supported": True, "maxResults": 200},
+        "changePassword": {"supported": False},
+        "sort": {"supported": False},
+        "etag": {"supported": False},
+        "authenticationSchemes": [{
+            "name": "OAuth Bearer Token",
+            "description": "Authentication scheme using the OAuth Bearer Token Standard",
+            "specUri": "http://www.rfc-editor.org/info/rfc6750",
+            "type": "oauthbearertoken",
+            "primary": True,
+        }],
+    })
+
+
+@scim_bp.route("/v2/Schemas")
+def schemas():
+    return jsonify({
+        "schemas": [SCIM_LIST_SCHEMA],
+        "totalResults": 1,
+        "Resources": [{
+            "id": SCIM_USER_SCHEMA,
+            "name": "User",
+            "description": "User account",
+        }],
+    })
+
+
+@scim_bp.route("/v2/ResourceTypes")
+def resource_types():
+    return jsonify({
+        "schemas": [SCIM_LIST_SCHEMA],
+        "totalResults": 1,
+        "Resources": [{
+            "id": "User",
+            "name": "User",
+            "endpoint": "/Users",
+            "schema": SCIM_USER_SCHEMA,
+        }],
+    })
+
+
+# ---------------------------------------------------------------------------
+# Users
+# ---------------------------------------------------------------------------
+
+
+@scim_bp.route("/v2/Users")
+def list_users():
+    ws, err = _check_auth()
+    if err is not None:
+        return err
+
+    members = WorkspaceMember.query.filter_by(workspace_id=ws.id).all()
+    resources = []
+    for m in members:
+        if m.user is None:
+            continue
+        resources.append(_user_to_scim(m.user, ws, role=m.role))
+
+    return jsonify({
+        "schemas": [SCIM_LIST_SCHEMA],
+        "totalResults": len(resources),
+        "Resources": resources,
+        "startIndex": 1,
+        "itemsPerPage": len(resources),
+    })
+
+
+@scim_bp.route("/v2/Users/<int:user_id>")
+def get_user(user_id):
+    ws, err = _check_auth()
+    if err is not None:
+        return err
+    user = User.query.get(user_id)
+    if user is None:
+        return _scim_error("User not found", 404)
+    member = _existing_membership(ws, user)
+    if member is None:
+        return _scim_error("User not in workspace", 404)
+    return jsonify(_user_to_scim(user, ws, role=member.role))
+
+
+@scim_bp.route("/v2/Users", methods=["POST"])
+def create_user():
+    ws, err = _check_auth()
+    if err is not None:
+        return err
+
+    payload = request.get_json(silent=True) or {}
+    email = (
+        (payload.get("emails") or [{}])[0].get("value")
+        or payload.get("userName")
+        or ""
+    ).strip().lower()
+    if not email:
+        return _scim_error("emails or userName is required", 400)
+
+    user = User.query.filter_by(email=email).first()
+    if user is None:
+        user = User(email=email, username=email)
+        # Random password — IdP-provisioned users sign in via SAML/SSO,
+        # not local passwords. Setting one keeps the column non-null.
+        user.set_password(secrets.token_urlsafe(24))
+        db.session.add(user)
+        db.session.commit()
+
+    if _existing_membership(ws, user) is None:
+        ext = payload.get(
+            "urn:ietf:params:scim:schemas:extension:filenergy:2.0:User", {}
+        )
+        role = (ext.get("workspaceRole") or "member").lower()
+        if role not in ("owner", "admin", "member"):
+            role = "member"
+        db.session.add(WorkspaceMember(
+            workspace_id=ws.id, user_id=user.id, role=role,
+        ))
+        db.session.commit()
+
+    member = _existing_membership(ws, user)
+    return jsonify(_user_to_scim(user, ws, role=member.role)), 201
+
+
+@scim_bp.route("/v2/Users/<int:user_id>", methods=["PUT"])
+def replace_user(user_id):
+    ws, err = _check_auth()
+    if err is not None:
+        return err
+    user = User.query.get(user_id)
+    if user is None:
+        return _scim_error("User not found", 404)
+    member = _existing_membership(ws, user)
+    if member is None:
+        return _scim_error("User not in workspace", 404)
+
+    payload = request.get_json(silent=True) or {}
+    if payload.get("active") is False:
+        # IdP marks the user inactive → remove the membership but keep
+        # the user row (data, audit, GDPR).
+        db.session.delete(member)
+        db.session.commit()
+        return jsonify(_user_to_scim(user, ws, role=member.role))
+
+    ext = payload.get(
+        "urn:ietf:params:scim:schemas:extension:filenergy:2.0:User", {}
+    )
+    role = (ext.get("workspaceRole") or member.role).lower()
+    if role in ("owner", "admin", "member"):
+        member.role = role
+        db.session.commit()
+    return jsonify(_user_to_scim(user, ws, role=member.role))
+
+
+@scim_bp.route("/v2/Users/<int:user_id>", methods=["PATCH"])
+def patch_user(user_id):
+    """SCIM PATCH (RFC 7644 §3.5.2) — applies a list of operations."""
+    ws, err = _check_auth()
+    if err is not None:
+        return err
+    user = User.query.get(user_id)
+    if user is None:
+        return _scim_error("User not found", 404)
+    member = _existing_membership(ws, user)
+    if member is None:
+        return _scim_error("User not in workspace", 404)
+
+    payload = request.get_json(silent=True) or {}
+    operations = payload.get("Operations", [])
+    for op in operations:
+        path = (op.get("path") or "").lower()
+        value = op.get("value")
+        verb = (op.get("op") or "").lower()
+        if path == "active" and verb in ("replace", "add"):
+            active = value if isinstance(value, bool) else (
+                isinstance(value, dict) and value.get("active")
+            )
+            if active is False:
+                db.session.delete(member)
+                db.session.commit()
+                return jsonify(_user_to_scim(user, ws, role=member.role))
+    return jsonify(_user_to_scim(user, ws, role=member.role))
+
+
+@scim_bp.route("/v2/Users/<int:user_id>", methods=["DELETE"])
+def delete_user(user_id):
+    ws, err = _check_auth()
+    if err is not None:
+        return err
+    user = User.query.get(user_id)
+    if user is None:
+        return _scim_error("User not found", 404)
+    member = _existing_membership(ws, user)
+    if member is not None:
+        db.session.delete(member)
+        db.session.commit()
+    return "", 204

--- a/filenergy/views/settings_views.py
+++ b/filenergy/views/settings_views.py
@@ -88,12 +88,14 @@ def revoke_key(key_id):
 @settings_bp.route("/workspace")
 @login_required
 def workspace():
+    from filenergy.services import inbound_email
     return render_template(
         "settings/workspace.html",
         members=workspaces.members(g.workspace),
         invitations=workspaces.pending_invitations(g.workspace),
         my_role=workspaces.role_of(g.workspace, g.user),
         my_workspaces=workspaces.list_for_user(g.user),
+        inbound_address=inbound_email.address_for(g.workspace),
     )
 
 

--- a/migrations/versions/3735a05065f5_tier7_polish.py
+++ b/migrations/versions/3735a05065f5_tier7_polish.py
@@ -1,0 +1,56 @@
+"""tier7: file soft-delete, conversation pin/archive, collection share links
+
+Revision ID: 3735a05065f5
+Revises: cccbc12f8d17
+Create Date: 2026-05-01 04:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "3735a05065f5"
+down_revision = "cccbc12f8d17"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("file", sa.Column("deleted_at", sa.DateTime(), nullable=True))
+    op.create_index(
+        op.f("ix_file_deleted_at"), "file", ["deleted_at"], unique=False,
+    )
+    op.add_column("conversation", sa.Column("pinned_at", sa.DateTime(), nullable=True))
+    op.add_column("conversation", sa.Column("archived_at", sa.DateTime(), nullable=True))
+
+    op.create_table(
+        "collection_share_link",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("collection_id", sa.Integer(), nullable=True),
+        sa.Column("token", sa.String(length=64), nullable=True),
+        sa.Column("expires_at", sa.DateTime(), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(), nullable=True),
+        sa.Column("created_by_id", sa.Integer(), nullable=True),
+        sa.Column("view_count", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["collection_id"], ["collection.id"]),
+        sa.ForeignKeyConstraint(["created_by_id"], ["user.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_collection_share_link_collection_id"),
+        "collection_share_link", ["collection_id"], unique=False,
+    )
+    op.create_index(
+        op.f("ix_collection_share_link_token"),
+        "collection_share_link", ["token"], unique=True,
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_collection_share_link_token"), table_name="collection_share_link")
+    op.drop_index(op.f("ix_collection_share_link_collection_id"), table_name="collection_share_link")
+    op.drop_table("collection_share_link")
+    op.drop_column("conversation", "archived_at")
+    op.drop_column("conversation", "pinned_at")
+    op.drop_index(op.f("ix_file_deleted_at"), table_name="file")
+    op.drop_column("file", "deleted_at")

--- a/tests/test_tier5_features.py
+++ b/tests/test_tier5_features.py
@@ -180,6 +180,8 @@ def test_ask_stream_emits_message_id_meta(auth_client, db, user, workspace):
 
 
 def test_bulk_delete_via_json(auth_client, db, user, workspace, uploaded_file):
+    """Soft delete: row stays in the DB with `deleted_at` set so the
+    user can Undo. A cron job hard-deletes after the grace window."""
     from filenergy.models import File
 
     payload = json.dumps({"ids": [uploaded_file.id]})
@@ -189,7 +191,10 @@ def test_bulk_delete_via_json(auth_client, db, user, workspace, uploaded_file):
     )
     assert r.status_code == 200
     assert r.get_json()["deleted"] == 1
-    assert File.query.get(uploaded_file.id) is None
+    # Row still exists but is soft-deleted.
+    f = File.query.get(uploaded_file.id)
+    assert f is not None
+    assert f.deleted_at is not None
 
 
 def test_bulk_delete_handles_empty_payload(auth_client):

--- a/tests/test_tier7_features.py
+++ b/tests/test_tier7_features.py
@@ -1,0 +1,788 @@
+"""Tier-7 feature tests:
+
+- File soft-delete + undo (bulk_delete sets deleted_at, bulk_restore clears it).
+- File rename endpoint.
+- Conversation pin / archive toggles + sidebar ordering / filtering.
+- Collection share link (mint + public read-only landing).
+- Reranker: claude backend reorders, noop is passthrough, fallback on error.
+- Email-to-ingest: address derivation, payload routing, attachment ingest.
+- SCIM: auth headers, list/get/create/replace/patch/delete users.
+- Landing page renders the new hero + pricing.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+
+import pytest
+
+
+# ---------- File soft-delete + undo --------------------------------------
+
+
+def test_bulk_restore_clears_deleted_at(auth_client, db, user, workspace, uploaded_file):
+    """After a soft-delete, /file/bulk_restore/ clears `deleted_at`."""
+    from filenergy.models import File
+
+    auth_client.post(
+        "/file/bulk_delete/",
+        data=json.dumps({"ids": [uploaded_file.id]}),
+        content_type="application/json",
+    )
+    f = File.query.get(uploaded_file.id)
+    assert f.deleted_at is not None
+
+    r = auth_client.post(
+        "/file/bulk_restore/",
+        data=json.dumps({"ids": [uploaded_file.id]}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    assert r.get_json()["restored"] == 1
+    f = File.query.get(uploaded_file.id)
+    assert f.deleted_at is None
+
+
+def test_soft_deleted_files_hidden_from_listing(auth_client, db, user, workspace, uploaded_file):
+    auth_client.post(
+        "/file/bulk_delete/",
+        data=json.dumps({"ids": [uploaded_file.id]}),
+        content_type="application/json",
+    )
+    r = auth_client.get("/file/list/")
+    assert r.status_code == 200
+    assert uploaded_file.name.encode() not in r.data
+
+
+def test_purge_cli_hard_deletes_after_grace(monkeypatch, app, db, user, workspace, uploaded_file):
+    """The cron-style `flask purge-deleted-files` command hard-deletes
+    rows whose `deleted_at` is older than the grace window."""
+    from datetime import timedelta
+    from filenergy.models import File, utcnow
+
+    # Soft-delete the file.
+    auth_client_post = uploaded_file.id
+    f = File.query.get(uploaded_file.id)
+    f.deleted_at = utcnow() - timedelta(hours=48)
+    db.session.commit()
+
+    monkeypatch.setenv("FILENERGY_DELETE_GRACE_HOURS", "24")
+    runner = app.test_cli_runner()
+    result = runner.invoke(args=["purge-deleted-files"])
+    assert result.exit_code == 0
+    assert "purged" in result.output
+    assert File.query.get(uploaded_file.id) is None
+
+
+def test_purge_cli_keeps_within_grace(monkeypatch, app, db, user, workspace, uploaded_file):
+    from filenergy.models import File, utcnow
+
+    # Soft-deleted just now → should NOT be purged.
+    f = File.query.get(uploaded_file.id)
+    f.deleted_at = utcnow()
+    db.session.commit()
+
+    monkeypatch.setenv("FILENERGY_DELETE_GRACE_HOURS", "24")
+    runner = app.test_cli_runner()
+    runner.invoke(args=["purge-deleted-files"])
+    assert File.query.get(uploaded_file.id) is not None
+
+
+# ---------- File rename --------------------------------------------------
+
+
+def test_file_rename_endpoint_updates_name(auth_client, db, uploaded_file):
+    r = auth_client.post(
+        f"/file/{uploaded_file.id}/rename",
+        data=json.dumps({"name": "renamed.pdf"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    db.session.refresh(uploaded_file)
+    assert uploaded_file.name == "renamed.pdf"
+
+
+def test_file_rename_rejects_empty_name(auth_client, uploaded_file):
+    r = auth_client.post(
+        f"/file/{uploaded_file.id}/rename",
+        data=json.dumps({"name": ""}),
+        content_type="application/json",
+    )
+    assert r.status_code == 400
+
+
+def test_file_rename_rejects_other_workspaces(client, db, user, workspace, uploaded_file):
+    """A user from a different workspace can't rename your files."""
+    from filenergy.models import User
+    from filenergy.services import workspaces
+
+    bob = User(email="bob@example.com", username="bob@example.com")
+    bob.set_password("password"); db.session.add(bob); db.session.commit()
+    workspaces.ensure_default_for(bob)
+
+    client.post("/user/login/", data={"email": bob.email, "password": "password"})
+    r = client.post(
+        f"/file/{uploaded_file.id}/rename",
+        data=json.dumps({"name": "evil.pdf"}),
+        content_type="application/json",
+    )
+    assert r.status_code == 404
+
+
+# ---------- Conversation pin / archive ----------------------------------
+
+
+def _make_conv(db, user, workspace, title="t"):
+    from filenergy.models import Conversation
+    c = Conversation(user_id=user.id, workspace_id=workspace.id, title=title)
+    db.session.add(c); db.session.commit()
+    return c
+
+
+def test_pin_conversation_toggles(auth_client, db, user, workspace):
+    c = _make_conv(db, user, workspace)
+    r = auth_client.post(f"/ask/c/{c.id}/pin")
+    assert r.get_json()["pinned"] is True
+    db.session.refresh(c)
+    assert c.pinned_at is not None
+
+    r = auth_client.post(f"/ask/c/{c.id}/pin")
+    assert r.get_json()["pinned"] is False
+    db.session.refresh(c)
+    assert c.pinned_at is None
+
+
+def test_archive_conversation_toggles(auth_client, db, user, workspace):
+    c = _make_conv(db, user, workspace)
+    r = auth_client.post(f"/ask/c/{c.id}/archive")
+    assert r.get_json()["archived"] is True
+    db.session.refresh(c)
+    assert c.archived_at is not None
+
+
+def test_archived_conversation_hidden_from_sidebar(auth_client, db, user, workspace):
+    """The default conv list excludes archived threads."""
+    from filenergy.services import conversations
+
+    a = _make_conv(db, user, workspace, "active thread")
+    b = _make_conv(db, user, workspace, "old thread")
+    auth_client.post(f"/ask/c/{b.id}/archive")
+    convs = conversations.list_for_user(user, workspace)
+    titles = [c.title for c in convs]
+    assert "active thread" in titles
+    assert "old thread" not in titles
+
+
+def test_pinned_conversations_float_to_top(auth_client, db, user, workspace):
+    from filenergy.services import conversations
+
+    a = _make_conv(db, user, workspace, "first")
+    b = _make_conv(db, user, workspace, "second")
+    c = _make_conv(db, user, workspace, "third")
+    # Pin `a`, the oldest. Should jump to the top.
+    auth_client.post(f"/ask/c/{a.id}/pin")
+    convs = conversations.list_for_user(user, workspace)
+    assert convs[0].id == a.id
+
+
+# ---------- Collection share --------------------------------------------
+
+
+def test_collection_share_mint_returns_token(auth_client, db, user, workspace):
+    from filenergy.models import Collection, CollectionShareLink
+
+    coll = Collection(workspace_id=workspace.id, name="Demo", slug="demo")
+    db.session.add(coll); db.session.commit()
+    r = auth_client.post(
+        f"/collections/{coll.slug}/share",
+        data="{}", content_type="application/json",
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["token"]
+    assert "/collections/share/" in body["url"]
+    link = CollectionShareLink.query.filter_by(token=body["token"]).first()
+    assert link is not None and link.collection_id == coll.id
+
+
+def test_collection_share_landing_is_public(client, db, user, workspace, uploaded_file):
+    from filenergy.models import Collection, CollectionShareLink, utcnow
+    import secrets as sec
+
+    coll = Collection(workspace_id=workspace.id, name="Demo", slug="demo")
+    db.session.add(coll); db.session.commit()
+    uploaded_file.collection_id = coll.id
+    db.session.commit()
+    link = CollectionShareLink(
+        collection_id=coll.id, token=sec.token_urlsafe(16),
+        created_by_id=user.id,
+    )
+    db.session.add(link); db.session.commit()
+
+    # Anonymous client can hit the landing.
+    r = client.get(f"/collections/share/{link.token}")
+    assert r.status_code == 200
+    assert b"Demo" in r.data
+    assert uploaded_file.name.encode() in r.data
+
+
+def test_collection_share_landing_404s_revoked(client, db, user, workspace):
+    from filenergy.models import Collection, CollectionShareLink, utcnow
+
+    coll = Collection(workspace_id=workspace.id, name="Demo", slug="demo2")
+    db.session.add(coll); db.session.commit()
+    link = CollectionShareLink(
+        collection_id=coll.id, token="xyz", created_by_id=user.id,
+        revoked_at=utcnow(),
+    )
+    db.session.add(link); db.session.commit()
+    r = client.get("/collections/share/xyz")
+    assert r.status_code == 404
+
+
+# ---------- Reranker -----------------------------------------------------
+
+
+def test_reranker_noop_passthrough(monkeypatch):
+    from filenergy.services import reranker
+    monkeypatch.setenv("FILENERGY_RERANKER", "noop")
+
+    # A list of (chunk-like, embedding-score) tuples.
+    class _C:
+        def __init__(self, content): self.content = content
+    cands = [(_C("a"), 0.9), (_C("b"), 0.8), (_C("c"), 0.7)]
+    out = reranker.rerank("?", cands)
+    # Top-K cap of 4 still applies.
+    assert out == cands[:4]
+
+
+def test_reranker_disabled_when_no_anthropic_key(monkeypatch):
+    from filenergy.services import reranker
+    from filenergy import settings
+
+    monkeypatch.setattr(settings, "ANTHROPIC_API_KEY", "")
+    monkeypatch.setenv("FILENERGY_RERANKER", "claude")
+    assert reranker.is_enabled() is False
+
+
+def test_reranker_claude_reorders_by_score(monkeypatch):
+    """When the Claude backend returns scores, the reranker sorts by them."""
+    from filenergy.services import reranker
+
+    class _C:
+        def __init__(self, content): self.content = content
+
+    # Three candidates; the embedding picked them in this order, but the
+    # rerank backend says #2 is best, then #0, then #1.
+    candidates = [(_C("a"), 0.9), (_C("b"), 0.8), (_C("c"), 0.7)]
+
+    class _Block:
+        type = "text"
+        text = '{"scores":[{"id":0,"score":3},{"id":1,"score":1},{"id":2,"score":9}]}'
+    class _Msg:
+        content = [_Block()]
+    class _Messages:
+        def create(self, **kwargs): return _Msg()
+    class _FakeClient:
+        messages = _Messages()
+
+    monkeypatch.setattr(
+        "filenergy.services.chat._client", lambda: _FakeClient()
+    )
+    monkeypatch.setenv("FILENERGY_RERANKER", "claude")
+    monkeypatch.setenv("FILENERGY_RERANK_TOP_K", "3")
+
+    out = reranker.rerank("?", candidates)
+    # New order: c (id=2, score 9) → a (id=0, score 3) → b (id=1, score 1).
+    assert [c.content for (c, _) in out] == ["c", "a", "b"]
+
+
+def test_reranker_falls_back_on_bad_json(monkeypatch):
+    from filenergy.services import reranker
+
+    class _C:
+        def __init__(self, content): self.content = content
+    candidates = [(_C("a"), 0.9), (_C("b"), 0.8)]
+
+    class _Block:
+        type = "text"
+        text = "not json"
+    class _Msg:
+        content = [_Block()]
+    class _Messages:
+        def create(self, **k): return _Msg()
+    class _FakeClient:
+        messages = _Messages()
+
+    monkeypatch.setattr("filenergy.services.chat._client", lambda: _FakeClient())
+    monkeypatch.setenv("FILENERGY_RERANKER", "claude")
+    out = reranker.rerank("?", candidates)
+    # Fallback returns the original embedding order, capped at top-K.
+    assert [c.content for (c, _) in out] == ["a", "b"]
+
+
+# ---------- Email-to-ingest ---------------------------------------------
+
+
+def test_inbound_email_address_format(monkeypatch, db, workspace):
+    from filenergy.services import inbound_email
+
+    monkeypatch.setenv("FILENERGY_INBOUND_DOMAIN", "filenergy.app")
+    monkeypatch.setenv("FILENERGY_INBOUND_SECRET", "test-secret")
+    addr = inbound_email.address_for(workspace)
+    assert addr.startswith(f"inbox-{workspace.slug}-")
+    assert addr.endswith("@filenergy.app")
+
+
+def test_inbound_email_disabled_when_unset(monkeypatch, workspace):
+    from filenergy.services import inbound_email
+    monkeypatch.delenv("FILENERGY_INBOUND_DOMAIN", raising=False)
+    monkeypatch.delenv("FILENERGY_INBOUND_SECRET", raising=False)
+    assert inbound_email.is_configured() is False
+    assert inbound_email.address_for(workspace) == ""
+
+
+def test_inbound_email_ingest_creates_files(monkeypatch, app, db, user, workspace):
+    from filenergy.models import File
+    from filenergy.services import inbound_email
+
+    monkeypatch.setenv("FILENERGY_INBOUND_DOMAIN", "filenergy.app")
+    monkeypatch.setenv("FILENERGY_INBOUND_SECRET", "test-secret")
+    addr = inbound_email.address_for(workspace)
+
+    payload = {
+        "to": addr,
+        "from": "alice@example.com",
+        "subject": "Q4 review",
+        "text": "Here's the latest draft.",
+        "attachments": [{
+            "filename": "draft.txt",
+            "content": base64.b64encode(b"hello world").decode(),
+            "content_type": "text/plain",
+        }],
+    }
+    result = inbound_email.ingest_payload(payload)
+    assert result["ok"] is True
+    assert result["ingested"] == 2  # body + 1 attachment
+
+    files = File.query.filter_by(workspace_id=workspace.id).all()
+    names = {f.name for f in files}
+    # `materialize_blob` slugifies whitespace → hyphens for filename safety.
+    assert "Q4-review.md" in names
+    assert "draft.txt" in names
+
+
+def test_inbound_email_rejects_unknown_address(monkeypatch, app, db, user, workspace):
+    from filenergy.services import inbound_email
+
+    monkeypatch.setenv("FILENERGY_INBOUND_DOMAIN", "filenergy.app")
+    monkeypatch.setenv("FILENERGY_INBOUND_SECRET", "test-secret")
+    result = inbound_email.ingest_payload({
+        "to": "inbox-bogus-deadbeef0000@filenergy.app",
+        "subject": "x", "text": "y", "attachments": [],
+    })
+    assert result["ok"] is False
+
+
+def test_inbound_email_rejects_forged_token(monkeypatch, app, db, user, workspace):
+    """Use the right slug but a wrong HMAC token — should not match."""
+    from filenergy.services import inbound_email
+
+    monkeypatch.setenv("FILENERGY_INBOUND_DOMAIN", "filenergy.app")
+    monkeypatch.setenv("FILENERGY_INBOUND_SECRET", "test-secret")
+    bad = f"inbox-{workspace.slug}-000000000000@filenergy.app"
+    result = inbound_email.ingest_payload({
+        "to": bad, "subject": "x", "text": "y", "attachments": [],
+    })
+    assert result["ok"] is False
+
+
+def test_inbound_email_endpoint_returns_503_when_disabled(client, monkeypatch):
+    monkeypatch.delenv("FILENERGY_INBOUND_DOMAIN", raising=False)
+    monkeypatch.delenv("FILENERGY_INBOUND_SECRET", raising=False)
+    r = client.post("/inbound/email", data="{}", content_type="application/json")
+    assert r.status_code == 503
+
+
+def test_inbound_email_endpoint_checks_provider_secret(client, monkeypatch, workspace):
+    from filenergy.services import inbound_email
+    monkeypatch.setenv("FILENERGY_INBOUND_DOMAIN", "filenergy.app")
+    monkeypatch.setenv("FILENERGY_INBOUND_SECRET", "test-secret")
+    monkeypatch.setenv("FILENERGY_INBOUND_SHARED_SECRET", "provider-shared")
+
+    r = client.post(
+        "/inbound/email",
+        data=json.dumps({"to": inbound_email.address_for(workspace)}),
+        content_type="application/json",
+    )
+    assert r.status_code == 401  # missing X-Inbound-Secret header
+
+    r = client.post(
+        "/inbound/email",
+        data=json.dumps({"to": inbound_email.address_for(workspace)}),
+        content_type="application/json",
+        headers={"X-Inbound-Secret": "provider-shared"},
+    )
+    assert r.status_code == 200
+
+
+# ---------- SCIM 2.0 -----------------------------------------------------
+
+
+def test_scim_disabled_without_token(client, monkeypatch):
+    monkeypatch.delenv("FILENERGY_SCIM_TOKEN", raising=False)
+    r = client.get("/scim/v2/Users", headers={"Authorization": "Bearer x"})
+    assert r.status_code == 503
+
+
+def test_scim_rejects_bad_bearer(client, monkeypatch, workspace):
+    monkeypatch.setenv("FILENERGY_SCIM_TOKEN", "good-token")
+    r = client.get(
+        "/scim/v2/Users",
+        headers={
+            "Authorization": "Bearer wrong",
+            "X-Filenergy-Workspace-Slug": workspace.slug,
+        },
+    )
+    assert r.status_code == 401
+
+
+def test_scim_lists_workspace_members(client, monkeypatch, workspace, user):
+    monkeypatch.setenv("FILENERGY_SCIM_TOKEN", "good-token")
+    r = client.get(
+        "/scim/v2/Users",
+        headers={
+            "Authorization": "Bearer good-token",
+            "X-Filenergy-Workspace-Slug": workspace.slug,
+        },
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["totalResults"] >= 1
+    assert any(
+        u["userName"] == user.email for u in body["Resources"]
+    )
+
+
+def test_scim_create_user_provisions(client, monkeypatch, db, workspace):
+    from filenergy.models import User, WorkspaceMember
+
+    monkeypatch.setenv("FILENERGY_SCIM_TOKEN", "good-token")
+    r = client.post(
+        "/scim/v2/Users",
+        headers={
+            "Authorization": "Bearer good-token",
+            "X-Filenergy-Workspace-Slug": workspace.slug,
+            "Content-Type": "application/json",
+        },
+        data=json.dumps({
+            "userName": "scim@example.com",
+            "emails": [{"value": "scim@example.com", "primary": True}],
+            "active": True,
+        }),
+    )
+    assert r.status_code == 201
+    assert User.query.filter_by(email="scim@example.com").first() is not None
+    assert WorkspaceMember.query.join(User).filter(
+        User.email == "scim@example.com",
+        WorkspaceMember.workspace_id == workspace.id,
+    ).first() is not None
+
+
+def test_scim_patch_active_false_removes_membership(client, monkeypatch, db, workspace):
+    from filenergy.models import User, WorkspaceMember
+
+    monkeypatch.setenv("FILENERGY_SCIM_TOKEN", "good-token")
+    bob = User(email="bob@scim.example", username="bob@scim.example")
+    bob.set_password("pwd"); db.session.add(bob); db.session.commit()
+    db.session.add(WorkspaceMember(
+        workspace_id=workspace.id, user_id=bob.id, role="member",
+    ))
+    db.session.commit()
+
+    r = client.patch(
+        f"/scim/v2/Users/{bob.id}",
+        headers={
+            "Authorization": "Bearer good-token",
+            "X-Filenergy-Workspace-Slug": workspace.slug,
+            "Content-Type": "application/json",
+        },
+        data=json.dumps({
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+            "Operations": [{"op": "replace", "path": "active", "value": False}],
+        }),
+    )
+    assert r.status_code == 200
+    # Membership gone, user row preserved (audit + GDPR).
+    assert WorkspaceMember.query.filter_by(
+        workspace_id=workspace.id, user_id=bob.id,
+    ).first() is None
+    assert User.query.get(bob.id) is not None
+
+
+def test_scim_delete_removes_membership(client, monkeypatch, db, workspace):
+    from filenergy.models import User, WorkspaceMember
+
+    monkeypatch.setenv("FILENERGY_SCIM_TOKEN", "good-token")
+    eve = User(email="eve@scim.example", username="eve@scim.example")
+    eve.set_password("pwd"); db.session.add(eve); db.session.commit()
+    db.session.add(WorkspaceMember(
+        workspace_id=workspace.id, user_id=eve.id, role="member",
+    ))
+    db.session.commit()
+    r = client.delete(
+        f"/scim/v2/Users/{eve.id}",
+        headers={
+            "Authorization": "Bearer good-token",
+            "X-Filenergy-Workspace-Slug": workspace.slug,
+        },
+    )
+    assert r.status_code == 204
+    assert WorkspaceMember.query.filter_by(
+        workspace_id=workspace.id, user_id=eve.id,
+    ).first() is None
+
+
+def test_scim_service_provider_config_is_public(client, monkeypatch):
+    monkeypatch.setenv("FILENERGY_SCIM_TOKEN", "good-token")
+    r = client.get("/scim/v2/ServiceProviderConfig")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["patch"]["supported"] is True
+
+
+def test_scim_schemas_endpoint(client):
+    r = client.get("/scim/v2/Schemas")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["totalResults"] == 1
+    assert "User" in body["Resources"][0]["name"]
+
+
+def test_scim_resource_types_endpoint(client):
+    r = client.get("/scim/v2/ResourceTypes")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["Resources"][0]["endpoint"] == "/Users"
+
+
+def test_scim_missing_workspace_header(client, monkeypatch):
+    monkeypatch.setenv("FILENERGY_SCIM_TOKEN", "good-token")
+    r = client.get(
+        "/scim/v2/Users",
+        headers={"Authorization": "Bearer good-token"},
+    )
+    assert r.status_code == 400
+
+
+def test_scim_unknown_workspace(client, monkeypatch):
+    monkeypatch.setenv("FILENERGY_SCIM_TOKEN", "good-token")
+    r = client.get(
+        "/scim/v2/Users",
+        headers={
+            "Authorization": "Bearer good-token",
+            "X-Filenergy-Workspace-Slug": "nonexistent",
+        },
+    )
+    assert r.status_code == 404
+
+
+def test_scim_get_user_returns_member(client, monkeypatch, workspace, user):
+    monkeypatch.setenv("FILENERGY_SCIM_TOKEN", "good-token")
+    r = client.get(
+        f"/scim/v2/Users/{user.id}",
+        headers={
+            "Authorization": "Bearer good-token",
+            "X-Filenergy-Workspace-Slug": workspace.slug,
+        },
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["userName"] == user.email
+
+
+def test_scim_get_user_404_when_not_in_workspace(client, monkeypatch, workspace, db):
+    from filenergy.models import User
+
+    monkeypatch.setenv("FILENERGY_SCIM_TOKEN", "good-token")
+    other = User(email="other@example.com", username="other@example.com")
+    other.set_password("p"); db.session.add(other); db.session.commit()
+    r = client.get(
+        f"/scim/v2/Users/{other.id}",
+        headers={
+            "Authorization": "Bearer good-token",
+            "X-Filenergy-Workspace-Slug": workspace.slug,
+        },
+    )
+    assert r.status_code == 404
+
+
+def test_scim_get_user_404_when_unknown(client, monkeypatch, workspace):
+    monkeypatch.setenv("FILENERGY_SCIM_TOKEN", "good-token")
+    r = client.get(
+        "/scim/v2/Users/999999",
+        headers={
+            "Authorization": "Bearer good-token",
+            "X-Filenergy-Workspace-Slug": workspace.slug,
+        },
+    )
+    assert r.status_code == 404
+
+
+def test_scim_replace_user_changes_role(client, monkeypatch, db, workspace):
+    from filenergy.models import User, WorkspaceMember
+
+    monkeypatch.setenv("FILENERGY_SCIM_TOKEN", "good-token")
+    carol = User(email="carol@scim.example", username="carol@scim.example")
+    carol.set_password("p"); db.session.add(carol); db.session.commit()
+    db.session.add(WorkspaceMember(
+        workspace_id=workspace.id, user_id=carol.id, role="member",
+    ))
+    db.session.commit()
+
+    r = client.put(
+        f"/scim/v2/Users/{carol.id}",
+        headers={
+            "Authorization": "Bearer good-token",
+            "X-Filenergy-Workspace-Slug": workspace.slug,
+            "Content-Type": "application/json",
+        },
+        data=json.dumps({
+            "userName": carol.email,
+            "active": True,
+            "urn:ietf:params:scim:schemas:extension:filenergy:2.0:User": {
+                "workspaceRole": "admin",
+            },
+        }),
+    )
+    assert r.status_code == 200
+    m = WorkspaceMember.query.filter_by(
+        workspace_id=workspace.id, user_id=carol.id,
+    ).first()
+    assert m.role == "admin"
+
+
+def test_scim_replace_user_inactive_removes_membership(client, monkeypatch, db, workspace):
+    from filenergy.models import User, WorkspaceMember
+
+    monkeypatch.setenv("FILENERGY_SCIM_TOKEN", "good-token")
+    dan = User(email="dan@scim.example", username="dan@scim.example")
+    dan.set_password("p"); db.session.add(dan); db.session.commit()
+    db.session.add(WorkspaceMember(
+        workspace_id=workspace.id, user_id=dan.id, role="member",
+    ))
+    db.session.commit()
+
+    r = client.put(
+        f"/scim/v2/Users/{dan.id}",
+        headers={
+            "Authorization": "Bearer good-token",
+            "X-Filenergy-Workspace-Slug": workspace.slug,
+            "Content-Type": "application/json",
+        },
+        data=json.dumps({"userName": dan.email, "active": False}),
+    )
+    assert r.status_code == 200
+    assert WorkspaceMember.query.filter_by(
+        workspace_id=workspace.id, user_id=dan.id,
+    ).first() is None
+
+
+def test_scim_create_user_idempotent(client, monkeypatch, db, workspace):
+    """POST /Users with an existing email should reuse the user row."""
+    from filenergy.models import User
+
+    monkeypatch.setenv("FILENERGY_SCIM_TOKEN", "good-token")
+    payload = {
+        "userName": "shared@scim.example",
+        "emails": [{"value": "shared@scim.example", "primary": True}],
+        "active": True,
+    }
+    r1 = client.post(
+        "/scim/v2/Users",
+        headers={
+            "Authorization": "Bearer good-token",
+            "X-Filenergy-Workspace-Slug": workspace.slug,
+            "Content-Type": "application/json",
+        },
+        data=json.dumps(payload),
+    )
+    assert r1.status_code == 201
+    r2 = client.post(
+        "/scim/v2/Users",
+        headers={
+            "Authorization": "Bearer good-token",
+            "X-Filenergy-Workspace-Slug": workspace.slug,
+            "Content-Type": "application/json",
+        },
+        data=json.dumps(payload),
+    )
+    assert r2.status_code == 201
+    assert User.query.filter_by(email="shared@scim.example").count() == 1
+
+
+def test_scim_create_user_requires_email(client, monkeypatch, workspace):
+    monkeypatch.setenv("FILENERGY_SCIM_TOKEN", "good-token")
+    r = client.post(
+        "/scim/v2/Users",
+        headers={
+            "Authorization": "Bearer good-token",
+            "X-Filenergy-Workspace-Slug": workspace.slug,
+            "Content-Type": "application/json",
+        },
+        data=json.dumps({"active": True}),
+    )
+    assert r.status_code == 400
+
+
+def test_scim_delete_user_404_when_unknown(client, monkeypatch, workspace):
+    monkeypatch.setenv("FILENERGY_SCIM_TOKEN", "good-token")
+    r = client.delete(
+        "/scim/v2/Users/999999",
+        headers={
+            "Authorization": "Bearer good-token",
+            "X-Filenergy-Workspace-Slug": workspace.slug,
+        },
+    )
+    assert r.status_code == 404
+
+
+def test_scim_patch_no_op_returns_user(client, monkeypatch, db, workspace):
+    """PATCH with a no-op operation list shouldn't crash; should return user."""
+    from filenergy.models import User, WorkspaceMember
+
+    monkeypatch.setenv("FILENERGY_SCIM_TOKEN", "good-token")
+    f = User(email="f@scim.example", username="f@scim.example")
+    f.set_password("p"); db.session.add(f); db.session.commit()
+    db.session.add(WorkspaceMember(
+        workspace_id=workspace.id, user_id=f.id, role="member",
+    ))
+    db.session.commit()
+    r = client.patch(
+        f"/scim/v2/Users/{f.id}",
+        headers={
+            "Authorization": "Bearer good-token",
+            "X-Filenergy-Workspace-Slug": workspace.slug,
+            "Content-Type": "application/json",
+        },
+        data=json.dumps({"Operations": []}),
+    )
+    assert r.status_code == 200
+
+
+# ---------- Landing page renders -----------------------------------------
+
+
+def test_landing_renders_hero_and_pricing(client):
+    r = client.get("/")
+    assert r.status_code == 200
+    body = r.data
+    # Hero copy.
+    assert b"finally askable" in body
+    # Pricing tiers.
+    assert b"Free" in body and b"Pro" in body and b"Team" in body
+    # Logo strip.
+    assert b"Anthropic Claude" in body
+    # Final CTA.
+    assert b"Stop searching" in body

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -210,15 +210,20 @@ def test_make_public_404_for_other_user(client, db, uploaded_file):
     assert r.data == b"fail"
 
 
-def test_delete_endpoint_removes_file(auth_client, uploaded_file):
+def test_delete_endpoint_soft_deletes_file(auth_client, uploaded_file):
+    """Single delete is now a soft-delete; the row stays so users can Undo."""
     r = auth_client.post("/file/delete/", data={"id": uploaded_file.id})
-    assert r.data == b"ok"
-    assert File.query.count() == 0
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["ok"] is True
+    f = File.query.get(uploaded_file.id)
+    assert f is not None
+    assert f.deleted_at is not None
 
 
-def test_delete_returns_fail_for_unknown_id(auth_client):
+def test_delete_returns_404_for_unknown_id(auth_client):
     r = auth_client.post("/file/delete/", data={"id": 9999})
-    assert r.data == b"fail"
+    assert r.status_code == 404
 
 
 def test_reindex_endpoint(auth_client, uploaded_file):

--- a/tests/test_views_round5.py
+++ b/tests/test_views_round5.py
@@ -337,7 +337,18 @@ def test_bulk_delete(auth_client, db, user, workspace):
     )
     assert r.status_code == 200
     assert r.get_json()["deleted"] == 2
-    assert File.query.filter_by(workspace_id=workspace.id).count() == 1
+    # Soft-deleted: rows exist but `deleted_at` is set; only one
+    # remains "active" (deleted_at IS NULL).
+    active = (
+        File.query.filter_by(workspace_id=workspace.id)
+        .filter(File.deleted_at.is_(None)).count()
+    )
+    assert active == 1
+    soft_deleted = (
+        File.query.filter_by(workspace_id=workspace.id)
+        .filter(File.deleted_at.isnot(None)).count()
+    )
+    assert soft_deleted == 2
 
 
 def test_bulk_delete_empty_request(auth_client):


### PR DESCRIPTION
## Summary

The "ship-day" cut. Closes the engineering bets the user picked (reranking + SCIM + email-to-ingest), the polish bugs left from tier-5 (cmdk arrows, undo on delete, file rename, conversation pin/archive, collection share), and gives the project a real **landing page** so it's actually presentable to customers.

### Sellable surface
- **Landing page** — hero ("Your team's files, *finally askable*"), mock-chat screenshot, three-up value prop, how-it-works, 9-card feature grid, programmable-from-day-one code block, **Free / Pro / Team pricing**, final CTA.

### Engineering bets
- **Reranking** — `services/reranker.py`. Pulls 12 candidates, asks Claude Haiku to score each 0–10, keeps top-K. Configurable / disable-able.
- **SCIM 2.0** — `/scim/v2/*` (Users CRUD, Schemas, ResourceTypes, ServiceProviderConfig). Bearer token + `X-Filenergy-Workspace-Slug`. PATCH `active=false` removes membership but preserves the User row.
- **Email-to-ingest** — per-workspace `inbox-<slug>-<hmac12>@<domain>` with constant-time compare. POST `/inbound/email` accepts the provider-agnostic JSON shape; body → `.md`, each attachment → its own indexed file.

### Polish
- **Soft-delete + Undo toast** — new `File.deleted_at`, `bulk_restore` endpoint, 8s undo window, `flask purge-deleted-files` CLI for hard-delete after the grace window.
- **Conversation pin / archive** — new columns + endpoints + sidebar dropdown menu. Pinned threads float to top; archived hidden by default.
- **File rename** — inline-editable title on file detail page.
- **Collection share** — `/collections/<slug>/share` mints a public read-only landing at `/collections/share/<token>`.
- **Cmdk arrow-key navigation** + active-row highlight + keyboard hint footer.

## Test plan

- [x] **858 tests passing**
- [x] **Coverage 95.0%** (≥95% bar held)
- [x] New `tests/test_tier7_features.py` — 46 tests across soft-delete+undo+purge CLI, file rename ownership, conv pin/archive ordering, collection share + revocation, reranker (3 backends + fallback), email-to-ingest (address derivation, payload routing, forged-token rejection), SCIM (auth, all CRUD, idempotency, discovery endpoints), landing render.
- [x] Alembic migration `3735a05065f5` for the new columns + table.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V5mfhSQRZzyNxdsNx1ybWN)_